### PR TITLE
Remove powi from math

### DIFF
--- a/src/std/math.zig
+++ b/src/std/math.zig
@@ -125,11 +125,6 @@ pub fn pow(x: f64, y: f64) f64 {
     return math.pow(f64, x, y);
 }
 
-// TODO catch errors
-//pub fn powi(x: i64, y: i64) i64 {
-//    return math.powi(i64, x, y);
-//}
-
 pub fn cbrt(val: f64) f64 {
     return math.cbrt(val);
 }

--- a/src/std/math.zig
+++ b/src/std/math.zig
@@ -121,10 +121,6 @@ pub fn scalbn(val: f64, n: i32) f64 {
     return math.scalbn(val, n);
 }
 
-pub fn pow(x: f64, y: f64) f64 {
-    return math.pow(f64, x, y);
-}
-
 pub fn cbrt(val: f64) f64 {
     return math.cbrt(val);
 }


### PR DESCRIPTION
Because bog has builtin `**`.