### PR TITLE
Add bitops to std

### DIFF
--- a/src/std/math.zig
+++ b/src/std/math.zig
@@ -219,3 +219,15 @@ pub fn sin(val: f64) f64 {
 pub fn tan(val: f64) f64 {
     return math.tan(val);
 }
+
+pub fn clz(val: i64) i64 {
+    return @clz(i64, val);
+}
+
+pub fn ctz(val: i64) i64 {
+    return @ctz(i64, val);
+}
+
+pub fn popcount(val: i64) i64 {
+    return @popCount(i64, val);
+}


### PR DESCRIPTION
I got strange results :(
bog:
```Julia
const {print} = import("std.io")
const {clz, ctz, popcount} = import("std.bitops")

const i = -128
const u = 128

print(f"clz(i) {clz(i)}")
print(f"ctz)i) {ctz(i)}")
print(f"popcount(i) {popcount(i)}")

print(f"clz(u) {clz(u)}")
print(f"ctz(u) {ctz(u)}")
print(f"popcount(u) {popcount(u)}")
```
>clz(i) 57
ctz)i) 57
popcount(i) 57
clz(u) 1
ctz(u) 1
popcount(u) 1

Zig:
```zig
const std = @import("std");
const print = std.debug.print;
const rotl = std.math.rotl;
const rotr = std.math.rotr;

pub fn main() void {
	const u: u64 = 128;
	const i: i64 = -128;

	print("clz(u) {}\n", .{ @clz(u64, u) });
	print("ctz(u) {}\n", .{ @ctz(u64, u) });
	print("popcount(u) {}\n", .{ @popCount(u64, u) });

	print("clz(i) {}\n", .{ @clz(i64, i) });
	print("ctz(i) {}\n", .{ @ctz(i64, i) });
	print("popcount(i) {}\n", .{ @popCount(i64, i) });
}
```
>clz(u) 56
ctz(u) 7
popcount(u) 1
clz(i) 0
ctz(i) 7
popcount(i) 57