### PR TITLE
zig update: remove fma

### DIFF
--- a/src/std/math.zig
+++ b/src/std/math.zig
@@ -180,10 +180,6 @@ pub fn log1p(val: f64) f64 {
     return math.log1p(val);
 }
 
-pub fn fma(x: f64, y: f64, z: f64) f64 {
-    return math.fma(f64, x, y, z);
-}
-
 pub fn asinh(val: f64) f64 {
     return math.asinh(val);
 }


### PR DESCRIPTION
The fma function appears to have been removed from zig std into
compiler_rt here: 41dd2beaacade94c5c98400a4a655aea07b9e2f3

It doesn't seem like bog uses this anywhere so I just removed it.