### PR TITLE
linenoize repl usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.zig text eol=lf
+lib/ linguist-vendored

--- a/build.zig
+++ b/build.zig
@@ -55,6 +55,7 @@ pub fn build(b: *Builder) void {
 
     var exe = b.addExecutable("bog", "src/main.zig");
     exe.setBuildMode(mode);
+    exe.addPackagePath("linenoize", "lib/linenoize/src/main.zig");
     exe.install();
 
     const fmt_step = b.step("fmt", "Format all source files");

--- a/lib/linenoize/LICENSE
+++ b/lib/linenoize/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Joachim Schmidt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/linenoize/build.zig
+++ b/lib/linenoize/build.zig
@@ -1,0 +1,53 @@
+const Builder = @import("std").build.Builder;
+
+pub fn build(b: *Builder) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
+
+    // Standard release options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
+    const mode = b.standardReleaseOptions();
+
+    // Static library
+    const lib = b.addStaticLibrary("linenoise", "src/c.zig");
+    lib.setTarget(target);
+    lib.setBuildMode(mode);
+    lib.linkLibC();
+    lib.install();
+
+    // Tests
+    var main_tests = b.addTest("src/main.zig");
+    main_tests.setTarget(target);
+    main_tests.setBuildMode(mode);
+
+    const test_step = b.step("test", "Run library tests");
+    test_step.dependOn(&main_tests.step);
+
+    // Zig example
+    var example = b.addExecutable("example", "examples/example.zig");
+    example.addPackagePath("linenoise", "src/main.zig");
+    example.setTarget(target);
+    example.setBuildMode(mode);
+
+    var example_run = example.run();
+
+    const example_step = b.step("example", "Run example");
+    example_step.dependOn(&example_run.step);
+
+    // C example
+    var c_example = b.addExecutable("example", "examples/example.c");
+    c_example.addIncludeDir("include");
+    c_example.linkLibC();
+    c_example.linkLibrary(lib);
+    c_example.setTarget(target);
+    c_example.setBuildMode(mode);
+
+    var c_example_run = c_example.run();
+
+    const c_example_step = b.step("c-example", "Run C example");
+    c_example_step.dependOn(&c_example_run.step);
+    c_example_step.dependOn(&lib.step);
+}

--- a/lib/linenoize/src/history.zig
+++ b/lib/linenoize/src/history.zig
@@ -1,0 +1,96 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+
+const max_line_len = 4096;
+
+pub const History = struct {
+    allocator: Allocator,
+    hist: ArrayListUnmanaged([]const u8) = .{},
+    max_len: usize = 100,
+    current: usize = 0,
+
+    const Self = @This();
+
+    /// Creates a new empty history
+    pub fn empty(allocator: Allocator) Self {
+        return Self{
+            .allocator = allocator,
+        };
+    }
+
+    /// Deinitializes the history
+    pub fn deinit(self: *Self) void {
+        for (self.hist.items) |x| self.allocator.free(x);
+        self.hist.deinit(self.allocator);
+    }
+
+    /// Ensures that at most self.max_len items are in the history
+    fn truncate(self: *Self) void {
+        if (self.hist.items.len > self.max_len) {
+            const surplus = self.hist.items.len - self.max_len;
+            for (self.hist.items[0..surplus]) |x| self.allocator.free(x);
+            std.mem.copy([]const u8, self.hist.items[0..self.max_len], self.hist.items[surplus..]);
+            self.hist.shrinkAndFree(self.allocator, self.max_len);
+        }
+    }
+
+    /// Adds this line to the history. Does not take ownership of the line, but
+    /// instead copies it
+    pub fn add(self: *Self, line: []const u8) !void {
+        if (self.hist.items.len < 1 or !std.mem.eql(u8, line, self.hist.items[self.hist.items.len - 1])) {
+            try self.hist.append(self.allocator, try self.allocator.dupe(u8, line));
+            self.truncate();
+        }
+    }
+
+    /// Removes the last item (newest item) of the history
+    pub fn pop(self: *Self) void {
+        self.allocator.free(self.hist.pop());
+    }
+
+    /// Loads the history from a file
+    pub fn load(self: *Self, path: []const u8) !void {
+        const file = try std.fs.cwd().openFile(path, .{});
+        defer file.close();
+
+        const reader = file.reader();
+        while (reader.readUntilDelimiterAlloc(self.allocator, '\n', max_line_len)) |line| {
+            try self.hist.append(self.allocator, line);
+        } else |err| {
+            switch (err) {
+                error.EndOfStream => return,
+                else => return err,
+            }
+        }
+
+        self.truncate();
+    }
+
+    /// Saves the history to a file
+    pub fn save(self: *Self, path: []const u8) !void {
+        const file = try std.fs.cwd().createFile(path, .{});
+        defer file.close();
+
+        for (self.hist.items) |line| {
+            try file.writeAll(line);
+            try file.writeAll("\n");
+        }
+    }
+
+    /// Sets the maximum number of history items. If more history
+    /// items than len exist, this will truncate the history to the
+    /// len most recent items.
+    pub fn setMaxLen(self: *Self, len: usize) !void {
+        self.max_len = len;
+        self.truncate();
+    }
+};
+
+test "history" {
+    var hist = History.empty(std.testing.allocator);
+    defer hist.deinit();
+
+    try hist.add("Hello");
+    hist.pop();
+}

--- a/lib/linenoize/src/main.zig
+++ b/lib/linenoize/src/main.zig
@@ -1,0 +1,209 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+const File = std.fs.File;
+
+const LinenoiseState = @import("state.zig").LinenoiseState;
+pub const History = @import("history.zig").History;
+const term = @import("term.zig");
+const isUnsupportedTerm = term.isUnsupportedTerm;
+const enableRawMode = term.enableRawMode;
+const disableRawMode = term.disableRawMode;
+const getColumns = term.getColumns;
+
+pub const HintsCallback = *fn (Allocator, []const u8) Allocator.Error!?[]const u8;
+pub const CompletionsCallback = *fn (Allocator, []const u8) Allocator.Error![]const []const u8;
+
+const key_null = 0;
+const key_ctrl_a = 1;
+const key_ctrl_b = 2;
+const key_ctrl_c = 3;
+const key_ctrl_d = 4;
+const key_ctrl_e = 5;
+const key_ctrl_f = 6;
+const key_ctrl_h = 8;
+const key_tab = 9;
+const key_ctrl_k = 11;
+const key_ctrl_l = 12;
+const key_enter = 13;
+const key_ctrl_n = 14;
+const key_ctrl_p = 16;
+const key_ctrl_t = 20;
+const key_ctrl_u = 21;
+const key_ctrl_w = 23;
+const key_esc = 27;
+const key_backspace = 127;
+
+pub fn linenoiseEdit(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+    var state = LinenoiseState.init(ln, in, out, prompt);
+    defer state.buf.deinit(state.allocator);
+
+    try state.ln.history.add("");
+    state.ln.history.current = state.ln.history.hist.items.len - 1;
+    try state.refreshLine();
+
+    while (true) {
+        var input_buf: [1]u8 = undefined;
+        if ((try in.read(&input_buf)) < 1) return null;
+        var c = input_buf[0];
+
+        // Browse completions before editing
+        if (c == key_tab) {
+            if (try state.browseCompletions()) |new_c| {
+                c = new_c;
+            }
+        }
+
+        switch (c) {
+            key_null, key_tab => {},
+            key_ctrl_a => try state.editMoveHome(),
+            key_ctrl_b => try state.editMoveLeft(),
+            key_ctrl_c => return error.CtrlC,
+            key_ctrl_d => {
+                if (state.buf.items.len > 0) {
+                    try state.editDelete();
+                } else {
+                    state.ln.history.pop();
+                    return null;
+                }
+            },
+            key_ctrl_e => try state.editMoveEnd(),
+            key_ctrl_f => try state.editMoveRight(),
+            key_ctrl_k => try state.editKillLineForward(),
+            key_ctrl_l => {
+                try term.clearScreen();
+                try state.refreshLine();
+            },
+            key_enter => {
+                state.ln.history.pop();
+                return try ln.allocator.dupe(u8, state.buf.items);
+            },
+            key_ctrl_n => try state.editHistoryNext(.next),
+            key_ctrl_p => try state.editHistoryNext(.prev),
+            key_ctrl_t => try state.editSwapPrev(),
+            key_ctrl_u => try state.editKillLineBackward(),
+            key_ctrl_w => try state.editDeletePrevWord(),
+            key_esc => {
+                if ((try in.read(&input_buf)) < 1) return null;
+                switch (input_buf[0]) {
+                    'b' => try state.editMoveWordStart(),
+                    'f' => try state.editMoveWordEnd(),
+                    '[' => {
+                        if ((try in.read(&input_buf)) < 1) return null;
+                        switch (input_buf[0]) {
+                            '0'...'9' => {
+                                const num = input_buf[0];
+                                if ((try in.read(&input_buf)) < 1) return null;
+                                if (num == '3' and input_buf[0] == '~')
+                                    try state.editDelete();
+                            },
+                            'A' => try state.editHistoryNext(.prev),
+                            'B' => try state.editHistoryNext(.next),
+                            'C' => try state.editMoveRight(),
+                            'D' => try state.editMoveLeft(),
+                            'H' => try state.editMoveHome(),
+                            'F' => try state.editMoveEnd(),
+                            else => {},
+                        }
+                    },
+                    '0' => {
+                        if ((try in.read(&input_buf)) < 1) return null;
+                        switch (input_buf[0]) {
+                            'H' => try state.editMoveHome(),
+                            'F' => try state.editMoveEnd(),
+                            else => {},
+                        }
+                    },
+                    else => {},
+                }
+            },
+            key_backspace, key_ctrl_h => try state.editBackspace(),
+            else => {
+                var utf8_buf: [4]u8 = undefined;
+                const utf8_len = std.unicode.utf8CodepointSequenceLength(c) catch continue;
+
+                utf8_buf[0] = c;
+                if ((try in.read(utf8_buf[1..utf8_len])) < utf8_len - 1) return null;
+
+                try state.editInsert(utf8_buf[0..utf8_len]);
+            },
+        }
+    }
+}
+
+/// Read a line with custom line editing mechanics. This includes hints,
+/// completions and history
+pub fn linenoiseRaw(ln: *Linenoise, in: File, out: File, prompt: []const u8) !?[]const u8 {
+    defer out.writeAll("\n") catch {};
+
+    const orig = try enableRawMode(in);
+    defer disableRawMode(in, orig);
+
+    return try linenoiseEdit(ln, in, out, prompt);
+}
+
+/// Read a line with no special features (no hints, no completions, no history)
+pub fn linenoiseNoTTY(allocator: Allocator, stdin: File) !?[]const u8 {
+    var reader = stdin.reader();
+    const max_line_len = std.math.maxInt(usize);
+    return reader.readUntilDelimiterAlloc(allocator, '\n', max_line_len) catch |e| switch (e) {
+        error.EndOfStream => return null,
+        else => return e,
+    };
+}
+
+pub const Linenoise = struct {
+    allocator: Allocator,
+    history: History,
+    multiline_mode: bool = false,
+    mask_mode: bool = false,
+    is_tty: bool = false,
+    term_supported: bool = false,
+    hints_callback: ?HintsCallback = null,
+    completions_callback: ?CompletionsCallback = null,
+
+    const Self = @This();
+
+    /// Initialize a linenoise struct
+    pub fn init(allocator: Allocator) Self {
+        var self = Self{
+            .allocator = allocator,
+            .history = History.empty(allocator),
+        };
+        self.examineStdIo();
+        return self;
+    }
+
+    /// Free all resources occupied by this struct
+    pub fn deinit(self: *Self) void {
+        self.history.deinit();
+    }
+
+    /// Re-examine (currently) stdin and environment variables to
+    /// check if line editing and prompt printing should be
+    /// enabled or not.
+    pub fn examineStdIo(self: *Self) void {
+        const stdin_file = std.io.getStdIn();
+        self.is_tty = stdin_file.isTty();
+        self.term_supported = !isUnsupportedTerm();
+    }
+
+    /// Reads a line from the terminal. Caller owns returned memory
+    pub fn linenoise(self: *Self, prompt: []const u8) !?[]const u8 {
+        const stdin_file = std.io.getStdIn();
+        const stdout_file = std.io.getStdOut();
+
+        if (self.is_tty and !self.term_supported) {
+            try stdout_file.writeAll(prompt);
+        }
+
+        return if (self.is_tty and self.term_supported)
+            try linenoiseRaw(self, stdin_file, stdout_file, prompt)
+        else
+            try linenoiseNoTTY(self.allocator, stdin_file);
+    }
+};
+
+test "all" {
+    _ = @import("history.zig");
+}

--- a/lib/linenoize/src/state.zig
+++ b/lib/linenoize/src/state.zig
@@ -1,0 +1,578 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+const ArrayListUnmanaged = std.ArrayListUnmanaged;
+const File = std.fs.File;
+const bufferedWriter = std.io.bufferedWriter;
+const math = std.math;
+
+const Linenoise = @import("main.zig").Linenoise;
+const History = @import("history.zig").History;
+const unicode = @import("unicode.zig");
+const width = unicode.width;
+const term = @import("term.zig");
+const getColumns = term.getColumns;
+
+const key_tab = 9;
+const key_esc = 27;
+
+const Bias = enum {
+    left,
+    right,
+};
+
+fn binarySearchBestEffort(
+    comptime T: type,
+    key: T,
+    items: []const T,
+    context: anytype,
+    comptime compareFn: fn (context: @TypeOf(context), lhs: T, rhs: T) math.Order,
+    bias: Bias,
+) usize {
+    var left: usize = 0;
+    var right: usize = items.len;
+
+    while (left < right) {
+        // Avoid overflowing in the midpoint calculation
+        const mid = left + (right - left) / 2;
+        // Compare the key with the midpoint element
+        switch (compareFn(context, key, items[mid])) {
+            .eq => return mid,
+            .gt => left = mid + 1,
+            .lt => right = mid,
+        }
+    }
+
+    // At this point, it is guaranteed that left >= right. In order
+    // for the bias to work, we need to return the exact opposite
+    return switch (bias) {
+        .left => right,
+        .right => left,
+    };
+}
+
+fn compareLeft(context: []const u8, avail_space: usize, index: usize) math.Order {
+    const width_slice = width(context[0..index]);
+    return math.order(avail_space, width_slice);
+}
+
+fn compareRight(context: []const u8, avail_space: usize, index: usize) math.Order {
+    const width_slice = width(context[index..]);
+    return math.order(width_slice, avail_space);
+}
+
+const StartOrEnd = enum {
+    start,
+    end,
+};
+
+/// Start mode: Calculates the optimal start position such that
+/// buf[start..] fits in the available space taking into account
+/// unicode codepoint widths
+///
+/// xxxxxxxxxxxxxxxxxxxxxxx buf
+///    [------------------] available_space
+///    ^                    start
+///
+/// End mode: Calculates the optimal end position so that buf[0..end]
+/// fits
+///
+/// xxxxxxxxxxxxxxxxxxxxxxx buf
+/// [----------]            available_space
+///            ^            end
+fn calculateStartOrEnd(
+    allocator: Allocator,
+    comptime mode: StartOrEnd,
+    buf: []const u8,
+    avail_space: usize,
+) !usize {
+    // Create a mapping from unicode codepoint indices to buf
+    // indices
+    var map = try std.ArrayListUnmanaged(usize).initCapacity(allocator, buf.len);
+    defer map.deinit(allocator);
+
+    var utf8 = (try std.unicode.Utf8View.init(buf)).iterator();
+    while (utf8.nextCodepointSlice()) |codepoint| {
+        map.appendAssumeCapacity(@ptrToInt(codepoint.ptr) - @ptrToInt(buf.ptr));
+    }
+
+    const codepoint_start = binarySearchBestEffort(
+        usize,
+        avail_space,
+        map.items,
+        buf,
+        switch (mode) {
+            .start => compareRight,
+            .end => compareLeft,
+        },
+        // When calculating start or end, if in doubt, choose a
+        // smaller buffer as we don't want to overflow the line. For
+        // calculating start, this means that we would rather have an
+        // index more to the right.
+        switch (mode) {
+            .start => .right,
+            .end => .left,
+        },
+    );
+    return map.items[codepoint_start];
+}
+
+pub const LinenoiseState = struct {
+    allocator: Allocator,
+    ln: *Linenoise,
+
+    stdin: File,
+    stdout: File,
+    buf: ArrayListUnmanaged(u8) = .{},
+    prompt: []const u8,
+    pos: usize = 0,
+    old_pos: usize = 0,
+    cols: usize,
+    max_rows: usize = 0,
+
+    const Self = @This();
+
+    pub fn init(ln: *Linenoise, in: File, out: File, prompt: []const u8) Self {
+        return Self{
+            .allocator = ln.allocator,
+            .ln = ln,
+
+            .stdin = in,
+            .stdout = out,
+            .prompt = prompt,
+            .cols = getColumns(in, out) catch 80,
+        };
+    }
+
+    pub fn browseCompletions(self: *Self) !?u8 {
+        var input_buf: [1]u8 = undefined;
+        var c: ?u8 = null;
+
+        const fun = self.ln.completions_callback orelse return null;
+        const completions = try fun(self.allocator, self.buf.items);
+        defer {
+            for (completions) |x| self.allocator.free(x);
+            self.allocator.free(completions);
+        }
+
+        if (completions.len == 0) {
+            try term.beep();
+        } else {
+            var finished = false;
+            var i: usize = 0;
+
+            while (!finished) {
+                if (i < completions.len) {
+                    // Change to completion nr. i
+                    // First, save buffer so we can restore it later
+                    const old_buf = self.buf.toOwnedSlice(self.allocator);
+                    const old_pos = self.pos;
+
+                    // Show suggested completion
+                    self.buf = .{};
+                    try self.buf.appendSlice(self.allocator, completions[i]);
+                    self.pos = self.buf.items.len;
+
+                    try self.refreshLine();
+
+                    // Restore original buffer into state
+                    self.buf.deinit(self.allocator);
+                    var new_buf = ArrayList(u8).fromOwnedSlice(self.allocator, old_buf);
+                    self.buf = new_buf.moveToUnmanaged();
+                    self.pos = old_pos;
+                } else {
+                    // Return to original line
+                    try self.refreshLine();
+                }
+
+                // Read next key
+                const nread = try self.stdin.read(&input_buf);
+                c = if (nread == 1) input_buf[0] else return error.NothingRead;
+
+                switch (c.?) {
+                    key_tab => {
+                        // Next completion
+                        i = (i + 1) % (completions.len + 1);
+                        if (i == completions.len) try term.beep();
+                    },
+                    key_esc => {
+                        // Stop browsing completions, return to buffer displayed
+                        // prior to browsing completions
+                        if (i < completions.len) try self.refreshLine();
+                        finished = true;
+                    },
+                    else => {
+                        // Stop browsing completions, potentially use suggested
+                        // completion
+                        if (i < completions.len) {
+                            // Replace buffer with text in the selected
+                            // completion
+                            self.buf.deinit(self.allocator);
+                            self.buf = .{};
+                            try self.buf.appendSlice(self.allocator, completions[i]);
+
+                            self.pos = self.buf.items.len;
+                        }
+                        finished = true;
+                    },
+                }
+            }
+        }
+
+        return c;
+    }
+
+    fn getHint(self: *Self) !?[]const u8 {
+        if (self.ln.hints_callback) |fun| {
+            return try fun(self.allocator, self.buf.items);
+        }
+
+        return null;
+    }
+
+    fn refreshSingleLine(self: *Self) !void {
+        var buf = bufferedWriter(self.stdout.writer());
+        var writer = buf.writer();
+
+        const hint = try self.getHint();
+        defer if (hint) |str| self.allocator.free(str);
+
+        // Calculate widths
+        const pos = width(self.buf.items[0..self.pos]);
+        const prompt_width = width(self.prompt);
+        const hint_width = if (hint) |str| width(str) else 0;
+        const buf_width = width(self.buf.items);
+
+        // Don't show hint/prompt when there is no space
+        const show_prompt = prompt_width < self.cols;
+        const display_prompt_width = if (show_prompt) prompt_width else 0;
+        const show_hint = display_prompt_width + hint_width < self.cols;
+        const display_hint_width = if (show_hint) hint_width else 0;
+
+        // buffer -> display_buf mapping
+        const avail_space = self.cols - display_prompt_width - display_hint_width - 1;
+        const whole_buffer_fits = buf_width <= avail_space;
+        var start: usize = undefined;
+        var end: usize = undefined;
+        if (whole_buffer_fits) {
+            start = 0;
+            end = self.buf.items.len;
+        } else {
+            if (pos < avail_space) {
+                start = 0;
+                end = try calculateStartOrEnd(
+                    self.allocator,
+                    .end,
+                    self.buf.items,
+                    avail_space,
+                );
+            } else {
+                end = self.pos;
+                start = try calculateStartOrEnd(
+                    self.allocator,
+                    .start,
+                    self.buf.items[0..end],
+                    avail_space,
+                );
+            }
+        }
+        const display_buf = self.buf.items[start..end];
+
+        // Move cursor to left edge
+        try writer.writeAll("\r");
+
+        // Write prompt
+        if (show_prompt) try writer.writeAll(self.prompt);
+
+        // Write current buffer content
+        if (self.ln.mask_mode) {
+            for (display_buf) |_| {
+                try writer.writeAll("*");
+            }
+        } else {
+            try writer.writeAll(display_buf);
+        }
+
+        // Show hints
+        if (show_hint) {
+            if (hint) |str| {
+                try writer.writeAll(str);
+            }
+        }
+
+        // Erase to the right
+        try writer.writeAll("\x1b[0K");
+
+        // Move cursor to original position
+        const cursor_pos = if (pos > avail_space) self.cols - display_hint_width - 1 else display_prompt_width + pos;
+        try writer.print("\r\x1b[{}C", .{cursor_pos});
+
+        // Write buffer
+        try buf.flush();
+    }
+
+    fn refreshMultiLine(self: *Self) !void {
+        var buf = bufferedWriter(self.stdout.writer());
+        var writer = buf.writer();
+
+        const hint = try self.getHint();
+        defer if (hint) |str| self.allocator.free(str);
+
+        // Calculate widths
+        const pos = width(self.buf.items[0..self.pos]);
+        const prompt_width = width(self.prompt);
+        const hint_width = if (hint) |str| width(str) else 0;
+        const buf_width = width(self.buf.items);
+        const total_width = prompt_width + buf_width + hint_width;
+
+        var rows = (total_width + self.cols - 1) / self.cols;
+        const old_rpos = (prompt_width + self.old_pos + self.cols) / self.cols;
+        const old_max_rows = self.max_rows;
+
+        if (rows > self.max_rows) {
+            self.max_rows = rows;
+        }
+
+        // Go to the last row
+        if (old_max_rows > old_rpos) {
+            try writer.print("\x1B[{}B", .{old_max_rows - old_rpos});
+        }
+
+        // Clear every row from bottom to top
+        if (old_max_rows > 0) {
+            var j: usize = 0;
+            while (j < old_max_rows - 1) : (j += 1) {
+                try writer.writeAll("\r\x1B[0K\x1B[1A");
+            }
+        }
+
+        // Clear the top line
+        try writer.writeAll("\r\x1B[0K");
+
+        // Write prompt
+        try writer.writeAll(self.prompt);
+
+        // Write current buffer content
+        if (self.ln.mask_mode) {
+            for (self.buf.items) |_| {
+                try writer.writeAll("*");
+            }
+        } else {
+            try writer.writeAll(self.buf.items);
+        }
+
+        // Show hints if applicable
+        if (hint) |str| {
+            try writer.writeAll(str);
+        }
+
+        // Reserve a newline if we filled all columns
+        if (self.pos > 0 and self.pos == self.buf.items.len and total_width % self.cols == 0) {
+            try writer.writeAll("\n\r");
+            rows += 1;
+            if (rows > self.max_rows) {
+                self.max_rows = rows;
+            }
+        }
+
+        // Move cursor to right position:
+        const rpos = (prompt_width + pos + self.cols) / self.cols;
+
+        // First, y position (move up if necessary)
+        if (rows > rpos) {
+            try writer.print("\x1B[{}A", .{rows - rpos});
+        }
+
+        // Then, x position (move right if necessary)
+        const col = (prompt_width + pos) % self.cols;
+        if (col > 0) {
+            try writer.print("\r\x1B[{}C", .{col});
+        } else {
+            try writer.writeAll("\r");
+        }
+
+        self.old_pos = pos;
+
+        try buf.flush();
+    }
+
+    pub fn refreshLine(self: *Self) !void {
+        if (self.ln.multiline_mode) {
+            try self.refreshMultiLine();
+        } else {
+            try self.refreshSingleLine();
+        }
+    }
+
+    pub fn editInsert(self: *Self, c: []const u8) !void {
+        try self.buf.resize(self.allocator, self.buf.items.len + c.len);
+        if (self.buf.items.len > 0 and self.pos < self.buf.items.len - c.len) {
+            std.mem.copyBackwards(
+                u8,
+                self.buf.items[self.pos + c.len .. self.buf.items.len],
+                self.buf.items[self.pos .. self.buf.items.len - c.len],
+            );
+        }
+
+        std.mem.copy(
+            u8,
+            self.buf.items[self.pos .. self.pos + c.len],
+            c,
+        );
+        self.pos += c.len;
+        try self.refreshLine();
+    }
+
+    fn prevCodepointLen(self: *Self, pos: usize) usize {
+        if (pos >= 1 and @clz(~self.buf.items[pos - 1]) == 0) {
+            return 1;
+        } else if (pos >= 2 and @clz(~self.buf.items[pos - 2]) == 2) {
+            return 2;
+        } else if (pos >= 3 and @clz(~self.buf.items[pos - 3]) == 3) {
+            return 3;
+        } else if (pos >= 4 and @clz(~self.buf.items[pos - 4]) == 4) {
+            return 4;
+        } else {
+            return 0;
+        }
+    }
+
+    pub fn editMoveLeft(self: *Self) !void {
+        if (self.pos == 0) return;
+        self.pos -= self.prevCodepointLen(self.pos);
+        try self.refreshLine();
+    }
+
+    pub fn editMoveRight(self: *Self) !void {
+        if (self.pos < self.buf.items.len) {
+            const utf8_len = std.unicode.utf8ByteSequenceLength(self.buf.items[self.pos]) catch 1;
+            self.pos += utf8_len;
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editMoveWordEnd(self: *Self) !void {
+        if (self.pos < self.buf.items.len) {
+            while (self.pos < self.buf.items.len and self.buf.items[self.pos] == ' ')
+                self.pos += 1;
+            while (self.pos < self.buf.items.len and self.buf.items[self.pos] != ' ')
+                self.pos += 1;
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editMoveWordStart(self: *Self) !void {
+        if (self.buf.items.len > 0 and self.pos > 0) {
+            while (self.pos > 0 and self.buf.items[self.pos - 1] == ' ')
+                self.pos -= 1;
+            while (self.pos > 0 and self.buf.items[self.pos - 1] != ' ')
+                self.pos -= 1;
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editMoveHome(self: *Self) !void {
+        if (self.pos > 0) {
+            self.pos = 0;
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editMoveEnd(self: *Self) !void {
+        if (self.pos < self.buf.items.len) {
+            self.pos = self.buf.items.len;
+            try self.refreshLine();
+        }
+    }
+
+    pub const HistoryDirection = enum {
+        next,
+        prev,
+    };
+
+    pub fn editHistoryNext(self: *Self, dir: HistoryDirection) !void {
+        if (self.ln.history.hist.items.len > 0) {
+            // Update the current history with the current line
+            const old_index = self.ln.history.current;
+            const current_entry = self.ln.history.hist.items[old_index];
+            self.ln.history.allocator.free(current_entry);
+            self.ln.history.hist.items[old_index] = try self.ln.history.allocator.dupe(u8, self.buf.items);
+
+            // Update history index
+            const new_index = switch (dir) {
+                .next => if (old_index < self.ln.history.hist.items.len - 1) old_index + 1 else self.ln.history.hist.items.len - 1,
+                .prev => if (old_index > 0) old_index - 1 else 0,
+            };
+            self.ln.history.current = new_index;
+
+            // Copy history entry to the current line buffer
+            self.buf.deinit(self.allocator);
+            self.buf = .{};
+            try self.buf.appendSlice(self.allocator, self.ln.history.hist.items[new_index]);
+            self.pos = self.buf.items.len;
+
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editDelete(self: *Self) !void {
+        if (self.buf.items.len > 0 and self.pos < self.buf.items.len) {
+            const utf8_len = std.unicode.utf8CodepointSequenceLength(self.buf.items[self.pos]) catch 1;
+            std.mem.copy(u8, self.buf.items[self.pos..], self.buf.items[self.pos + utf8_len ..]);
+            try self.buf.resize(self.allocator, self.buf.items.len - utf8_len);
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editBackspace(self: *Self) !void {
+        if (self.buf.items.len == 0 or self.pos == 0) return;
+
+        const len = self.prevCodepointLen(self.pos);
+        std.mem.copy(u8, self.buf.items[self.pos - len ..], self.buf.items[self.pos..]);
+        self.pos -= len;
+        try self.buf.resize(self.allocator, self.buf.items.len - len);
+        try self.refreshLine();
+    }
+
+    pub fn editSwapPrev(self: *Self) !void {
+        const prev_len = self.prevCodepointLen(self.pos);
+        const prevprev_len = self.prevCodepointLen(self.pos - prev_len);
+        if (prev_len == 0 or prevprev_len == 0) return;
+
+        var tmp: [4]u8 = undefined;
+        std.mem.copy(u8, &tmp, self.buf.items[self.pos - (prev_len + prevprev_len) .. self.pos - prev_len]);
+        std.mem.copy(u8, self.buf.items[self.pos - (prev_len + prevprev_len) ..], self.buf.items[self.pos - prev_len .. self.pos]);
+        std.mem.copy(u8, self.buf.items[self.pos - prevprev_len ..], tmp[0..prevprev_len]);
+
+        try self.refreshLine();
+    }
+
+    pub fn editDeletePrevWord(self: *Self) !void {
+        if (self.buf.items.len > 0 and self.pos > 0) {
+            const old_pos = self.pos;
+            while (self.pos > 0 and self.buf.items[self.pos - 1] == ' ')
+                self.pos -= 1;
+            while (self.pos > 0 and self.buf.items[self.pos - 1] != ' ')
+                self.pos -= 1;
+
+            const diff = old_pos - self.pos;
+            const new_len = self.buf.items.len - diff;
+            std.mem.copy(u8, self.buf.items[self.pos..new_len], self.buf.items[old_pos..]);
+            try self.buf.resize(self.allocator, new_len);
+            try self.refreshLine();
+        }
+    }
+
+    pub fn editKillLineForward(self: *Self) !void {
+        try self.buf.resize(self.allocator, self.pos);
+        try self.refreshLine();
+    }
+
+    pub fn editKillLineBackward(self: *Self) !void {
+        const new_len = self.buf.items.len - self.pos;
+        std.mem.copy(u8, self.buf.items, self.buf.items[self.pos..]);
+        self.pos = 0;
+        try self.buf.resize(self.allocator, new_len);
+        try self.refreshLine();
+    }
+};

--- a/lib/linenoize/src/term.zig
+++ b/lib/linenoize/src/term.zig
@@ -1,0 +1,107 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const File = std.fs.File;
+
+const tcflag_t = std.os.tcflag_t;
+
+const unsupported_term = [_][]const u8{ "dumb", "cons25", "emacs" };
+
+pub fn isUnsupportedTerm() bool {
+    const env_var = std.os.getenv("TERM") orelse return false;
+
+    return for (unsupported_term) |t| {
+        if (std.ascii.eqlIgnoreCase(env_var, t))
+            break true;
+    } else false;
+}
+
+pub fn enableRawMode(fd: File) !std.os.termios {
+    const orig = try std.os.tcgetattr(fd.handle);
+    var raw = orig;
+
+    // TODO fix hardcoding of linux
+    raw.iflag &= ~(@intCast(tcflag_t, std.os.linux.BRKINT) |
+        @intCast(tcflag_t, std.os.linux.ICRNL) |
+        @intCast(tcflag_t, std.os.linux.INPCK) |
+        @intCast(tcflag_t, std.os.linux.ISTRIP) |
+        @intCast(tcflag_t, std.os.linux.IXON));
+
+    raw.oflag &= ~(@intCast(tcflag_t, std.os.linux.OPOST));
+
+    raw.cflag |= (@intCast(tcflag_t, std.os.linux.CS8));
+
+    raw.lflag &= ~(@intCast(tcflag_t, std.os.linux.ECHO) |
+        @intCast(tcflag_t, std.os.linux.ICANON) |
+        @intCast(tcflag_t, std.os.linux.IEXTEN) |
+        @intCast(tcflag_t, std.os.linux.ISIG));
+
+    // FIXME
+    // raw.cc[std.os.VMIN] = 1;
+    // raw.cc[std.os.VTIME] = 0;
+
+    try std.os.tcsetattr(fd.handle, std.os.TCSA.FLUSH, raw);
+
+    return orig;
+}
+
+pub fn disableRawMode(fd: File, orig: std.os.termios) void {
+    std.os.tcsetattr(fd.handle, std.os.TCSA.FLUSH, orig) catch {};
+}
+
+fn getCursorPosition(in: File, out: File) !usize {
+    var buf: [32]u8 = undefined;
+    var reader = in.reader();
+
+    // Tell terminal to report cursor to in
+    try out.writeAll("\x1B[6n");
+
+    // Read answer
+    const answer = (try reader.readUntilDelimiterOrEof(&buf, 'R')) orelse
+        return error.CursorPos;
+
+    // Parse answer
+    if (!std.mem.startsWith(u8, "\x1B[", answer))
+        return error.CursorPos;
+
+    var iter = std.mem.split(u8, answer[2..], ";");
+    _ = iter.next() orelse return error.CursorPos;
+    const x = iter.next() orelse return error.CursorPos;
+
+    return try std.fmt.parseInt(usize, x, 10);
+}
+
+fn getColumnsFallback(in: File, out: File) !usize {
+    var writer = out.writer();
+    const orig_cursor_pos = try getCursorPosition(in, out);
+
+    try writer.print("\x1B[999C", .{});
+    const cols = try getCursorPosition(in, out);
+
+    try writer.print("\x1B[{}D", .{orig_cursor_pos});
+
+    return cols;
+}
+
+pub fn getColumns(in: File, out: File) !usize {
+    switch (builtin.os.tag) {
+        .linux => {
+            var wsz: std.os.linux.winsize = undefined;
+            if (std.os.linux.ioctl(in.handle, std.os.linux.T.IOCGWINSZ, @ptrToInt(&wsz)) == 0) {
+                return wsz.ws_col;
+            } else {
+                return try getColumnsFallback(in, out);
+            }
+        },
+        else => return try getColumnsFallback(in, out),
+    }
+}
+
+pub fn clearScreen() !void {
+    const stdout = std.io.getStdErr();
+    try stdout.writeAll("\x1b[H\x1b[2J");
+}
+
+pub fn beep() !void {
+    const stderr = std.io.getStdErr();
+    try stderr.writeAll("\x07");
+}

--- a/lib/linenoize/src/unicode.zig
+++ b/lib/linenoize/src/unicode.zig
@@ -1,0 +1,30 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const expectEqualSlices = std.testing.expectEqualSlices;
+
+const wcwidth = @import("zig-wcwidth/src/main.zig").wcwidth;
+
+pub fn width(s: []const u8) usize {
+    var result: usize = 0;
+
+    var escape_seq = false;
+    const view = std.unicode.Utf8View.init(s) catch return 0;
+    var iter = view.iterator();
+    while (iter.nextCodepoint()) |codepoint| {
+        if (escape_seq) {
+            if (codepoint == 'm') {
+                escape_seq = false;
+            }
+        } else {
+            if (codepoint == '\x1b') {
+                escape_seq = true;
+            } else {
+                const wcw = wcwidth(codepoint);
+                if (wcw < 0) return 0;
+                result += @intCast(usize, wcw);
+            }
+        }
+    }
+
+    return result;
+}

--- a/lib/linenoize/src/zig-wcwidth/LICENSE
+++ b/lib/linenoize/src/zig-wcwidth/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2020 Joachim Schmidt
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/lib/linenoize/src/zig-wcwidth/src/main.zig
+++ b/lib/linenoize/src/zig-wcwidth/src/main.zig
@@ -1,0 +1,160 @@
+const std = @import("std");
+const testing = std.testing;
+
+const zero_width_cf = @import("manual.zig").zero_width_cf;
+const wide_eastasian = @import("table_wide.zig").wide_eastasian;
+const zero_width = @import("table_zero.zig").zero_width;
+
+/// A simple binary search in a list containing lower and upper bounds
+fn tableBisearch(ucs: u21, table: []const [2]u21) bool {
+    var lbound: usize = 0;
+    var ubound: usize = table.len - 1;
+
+    // Out of entire table bounds
+    if (ucs < table[lbound][0] or ucs > table[ubound][1]) {
+        return false;
+    }
+
+    // Search table
+    while (ubound >= lbound) {
+        const mid = (lbound + ubound) / 2;
+        if (ucs > table[mid][1]) {
+            lbound = mid + 1;
+        } else if (ucs < table[mid][0]) {
+            ubound = mid - 1;
+        } else {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/// A simple binary search for a simple ordered list
+fn listBisearch(ucs: u21, list: []const u21) bool {
+    var lbound: usize = 0;
+    var ubound: usize = list.len - 1;
+
+    // Out of entire table bounds
+    if (ucs < list[lbound] or ucs > list[ubound]) {
+        return false;
+    }
+
+    // Search table
+    while (ubound >= lbound) {
+        const mid = (lbound + ubound) / 2;
+        if (ucs > list[mid]) {
+            lbound = mid + 1;
+        } else if (ucs < list[mid]) {
+            ubound = mid - 1;
+        } else {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/// Given one unicode character, return its printable length on a terminal.
+///
+/// The wcwidth() function returns 0 if the wc argument has no printable effect
+/// on a terminal (such as NUL '\0'), -1 if wc is not printable, or has an
+/// indeterminate effect on the terminal, such as a control character.
+/// Otherwise, the number of column positions the character occupies on a
+/// graphic terminal (1 or 2) is returned.
+///
+/// The following have a column width of -1:
+///
+///     - C0 control characters (U+001 through U+01F).
+///
+///     - C1 control characters and DEL (U+07F through U+0A0).
+///
+/// The following have a column width of 0:
+///
+///     - Non-spacing and enclosing combining characters (general
+///       category code Mn or Me in the Unicode database).
+///
+///     - NULL (U+0000, 0).
+///
+///     - COMBINING GRAPHEME JOINER (U+034F).
+///
+///     - ZERO WIDTH SPACE (U+200B) through
+///       RIGHT-TO-LEFT MARK (U+200F).
+///
+///     - LINE SEPERATOR (U+2028) and
+///       PARAGRAPH SEPERATOR (U+2029).
+///
+///     - LEFT-TO-RIGHT EMBEDDING (U+202A) through
+///       RIGHT-TO-LEFT OVERRIDE (U+202E).
+///
+///     - WORD JOINER (U+2060) through
+///       INVISIBLE SEPARATOR (U+2063).
+///
+/// The following have a column width of 1:
+///
+///     - SOFT HYPHEN (U+00AD) has a column width of 1.
+///
+///     - All remaining characters (including all printable
+///       ISO 8859-1 and WGL4 characters, Unicode control characters,
+///       etc.) have a column width of 1.
+///
+/// The following have a column width of 2:
+///
+///     - Spacing characters in the East Asian Wide (W) or East Asian
+///       Full-width (F) category as defined in Unicode Technical
+///       Report #11 have a column width of 2.
+pub fn wcwidth(wc: u21) isize {
+    // Manual list
+    if (listBisearch(wc, &zero_width_cf)) {
+        return 0;
+    }
+
+    // C0/C1 control characters
+    if (wc < 32 or 0x07F <= wc and wc < 0x0A0) {
+        return -1;
+    }
+
+    // combining characters with zero width
+    if (tableBisearch(wc, &zero_width)) {
+        return 0;
+    }
+
+    // double width
+    if (tableBisearch(wc, &wide_eastasian)) {
+        return 2;
+    } else {
+        return 1;
+    }
+}
+
+/// Given a unicode string, return its printable length on a terminal.
+///
+/// Returns ``-1`` if a non-printable character is encountered.
+pub fn wcswidth(wcs: []const u21) isize {
+    var width: isize = 0;
+
+    for (wcs) |char| {
+        const wcw = wcwidth(char);
+        if (wcw < 0) return -1;
+        width += wcw;
+    }
+
+    return width;
+}
+
+/// Given a byte slice, return its printable length on a terminal. Returns
+/// error.InvalidUtf8 when the byte slice does not contain valid UTF-8.
+///
+/// Returns ``-1`` if a non-printable character is encountered.
+pub fn sliceWidth(s: []const u8) !isize {
+    var width: isize = 0;
+
+    var utf8 = (try std.unicode.Utf8View.init(s)).iterator();
+    while (utf8.nextCodepoint()) |codepoint| {
+        const wcw = wcwidth(codepoint);
+        if (wcw < 0) return -1;
+        width += wcw;
+    }
+
+    return width;
+}

--- a/lib/linenoize/src/zig-wcwidth/src/manual.zig
+++ b/lib/linenoize/src/zig-wcwidth/src/manual.zig
@@ -1,0 +1,20 @@
+pub const zero_width_cf = [_]u21{
+    0, // Null (Cc)
+    0x034F, // Combining grapheme joiner (Mn)
+    0x200B, // Zero width space
+    0x200C, // Zero width non-joiner
+    0x200D, // Zero width joiner
+    0x200E, // Left-to-right mark
+    0x200F, // Right-to-left mark
+    0x2028, // Line separator (Zl)
+    0x2029, // Paragraph separator (Zp)
+    0x202A, // Left-to-right embedding
+    0x202B, // Right-to-left embedding
+    0x202C, // Pop directional formatting
+    0x202D, // Left-to-right override
+    0x202E, // Right-to-left override
+    0x2060, // Word joiner
+    0x2061, // Function application
+    0x2062, // Invisible times
+    0x2063, // Invisible separator
+};

--- a/lib/linenoize/src/zig-wcwidth/src/table_wide.zig
+++ b/lib/linenoize/src/zig-wcwidth/src/table_wide.zig
@@ -1,0 +1,466 @@
+pub const wide_eastasian = [_][2]u21{
+    [2]u21{
+        0x1100,
+        0x115f,
+    }, // Hangul Choseong Kiyeok  ..Hangul Choseong Filler
+    [2]u21{
+        0x231a,
+        0x231b,
+    }, // Watch                   ..Hourglass
+    [2]u21{
+        0x2329,
+        0x232a,
+    }, // Left-pointing Angle Brac..Right-pointing Angle Bra
+    [2]u21{
+        0x23e9,
+        0x23ec,
+    }, // Black Right-pointing Dou..Black Down-pointing Doub
+    [2]u21{
+        0x23f0,
+        0x23f0,
+    }, // Alarm Clock             ..Alarm Clock
+    [2]u21{
+        0x23f3,
+        0x23f3,
+    }, // Hourglass With Flowing S..Hourglass With Flowing S
+    [2]u21{
+        0x25fd,
+        0x25fe,
+    }, // White Medium Small Squar..Black Medium Small Squar
+    [2]u21{
+        0x2614,
+        0x2615,
+    }, // Umbrella With Rain Drops..Hot Beverage
+    [2]u21{
+        0x2648,
+        0x2653,
+    }, // Aries                   ..Pisces
+    [2]u21{
+        0x267f,
+        0x267f,
+    }, // Wheelchair Symbol       ..Wheelchair Symbol
+    [2]u21{
+        0x2693,
+        0x2693,
+    }, // Anchor                  ..Anchor
+    [2]u21{
+        0x26a1,
+        0x26a1,
+    }, // High Voltage Sign       ..High Voltage Sign
+    [2]u21{
+        0x26aa,
+        0x26ab,
+    }, // Medium White Circle     ..Medium Black Circle
+    [2]u21{
+        0x26bd,
+        0x26be,
+    }, // Soccer Ball             ..Baseball
+    [2]u21{
+        0x26c4,
+        0x26c5,
+    }, // Snowman Without Snow    ..Sun Behind Cloud
+    [2]u21{
+        0x26ce,
+        0x26ce,
+    }, // Ophiuchus               ..Ophiuchus
+    [2]u21{
+        0x26d4,
+        0x26d4,
+    }, // No Entry                ..No Entry
+    [2]u21{
+        0x26ea,
+        0x26ea,
+    }, // Church                  ..Church
+    [2]u21{
+        0x26f2,
+        0x26f3,
+    }, // Fountain                ..Flag In Hole
+    [2]u21{
+        0x26f5,
+        0x26f5,
+    }, // Sailboat                ..Sailboat
+    [2]u21{
+        0x26fa,
+        0x26fa,
+    }, // Tent                    ..Tent
+    [2]u21{
+        0x26fd,
+        0x26fd,
+    }, // Fuel Pump               ..Fuel Pump
+    [2]u21{
+        0x2705,
+        0x2705,
+    }, // White Heavy Check Mark  ..White Heavy Check Mark
+    [2]u21{
+        0x270a,
+        0x270b,
+    }, // Raised Fist             ..Raised Hand
+    [2]u21{
+        0x2728,
+        0x2728,
+    }, // Sparkles                ..Sparkles
+    [2]u21{
+        0x274c,
+        0x274c,
+    }, // Cross Mark              ..Cross Mark
+    [2]u21{
+        0x274e,
+        0x274e,
+    }, // Negative Squared Cross M..Negative Squared Cross M
+    [2]u21{
+        0x2753,
+        0x2755,
+    }, // Black Question Mark Orna..White Exclamation Mark O
+    [2]u21{
+        0x2757,
+        0x2757,
+    }, // Heavy Exclamation Mark S..Heavy Exclamation Mark S
+    [2]u21{
+        0x2795,
+        0x2797,
+    }, // Heavy Plus Sign         ..Heavy Division Sign
+    [2]u21{
+        0x27b0,
+        0x27b0,
+    }, // Curly Loop              ..Curly Loop
+    [2]u21{
+        0x27bf,
+        0x27bf,
+    }, // Double Curly Loop       ..Double Curly Loop
+    [2]u21{
+        0x2b1b,
+        0x2b1c,
+    }, // Black Large Square      ..White Large Square
+    [2]u21{
+        0x2b50,
+        0x2b50,
+    }, // White Medium Star       ..White Medium Star
+    [2]u21{
+        0x2b55,
+        0x2b55,
+    }, // Heavy Large Circle      ..Heavy Large Circle
+    [2]u21{
+        0x2e80,
+        0x2e99,
+    }, // Cjk Radical Repeat      ..Cjk Radical Rap
+    [2]u21{
+        0x2e9b,
+        0x2ef3,
+    }, // Cjk Radical Choke       ..Cjk Radical C-simplified
+    [2]u21{
+        0x2f00,
+        0x2fd5,
+    }, // Kangxi Radical One      ..Kangxi Radical Flute
+    [2]u21{
+        0x2ff0,
+        0x2ffb,
+    }, // Ideographic Description ..Ideographic Description
+    [2]u21{
+        0x3000,
+        0x303e,
+    }, // Ideographic Space       ..Ideographic Variation In
+    [2]u21{
+        0x3041,
+        0x3096,
+    }, // Hiragana Letter Small A ..Hiragana Letter Small Ke
+    [2]u21{
+        0x3099,
+        0x30ff,
+    }, // Combining Katakana-hirag..Katakana Digraph Koto
+    [2]u21{
+        0x3105,
+        0x312f,
+    }, // Bopomofo Letter B       ..Bopomofo Letter Nn
+    [2]u21{
+        0x3131,
+        0x318e,
+    }, // Hangul Letter Kiyeok    ..Hangul Letter Araeae
+    [2]u21{
+        0x3190,
+        0x31e3,
+    }, // Ideographic Annotation L..Cjk Stroke Q
+    [2]u21{
+        0x31f0,
+        0x321e,
+    }, // Katakana Letter Small Ku..Parenthesized Korean Cha
+    [2]u21{
+        0x3220,
+        0x3247,
+    }, // Parenthesized Ideograph ..Circled Ideograph Koto
+    [2]u21{
+        0x3250,
+        0x4dbf,
+    }, // Partnership Sign        ..
+    [2]u21{
+        0x4e00,
+        0xa48c,
+    }, // Cjk Unified Ideograph-4e..Yi Syllable Yyr
+    [2]u21{
+        0xa490,
+        0xa4c6,
+    }, // Yi Radical Qot          ..Yi Radical Ke
+    [2]u21{
+        0xa960,
+        0xa97c,
+    }, // Hangul Choseong Tikeut-m..Hangul Choseong Ssangyeo
+    [2]u21{
+        0xac00,
+        0xd7a3,
+    }, // Hangul Syllable Ga      ..Hangul Syllable Hih
+    [2]u21{
+        0xf900,
+        0xfaff,
+    }, // Cjk Compatibility Ideogr..
+    [2]u21{
+        0xfe10,
+        0xfe19,
+    }, // Presentation Form For Ve..Presentation Form For Ve
+    [2]u21{
+        0xfe30,
+        0xfe52,
+    }, // Presentation Form For Ve..Small Full Stop
+    [2]u21{
+        0xfe54,
+        0xfe66,
+    }, // Small Semicolon         ..Small Equals Sign
+    [2]u21{
+        0xfe68,
+        0xfe6b,
+    }, // Small Reverse Solidus   ..Small Commercial At
+    [2]u21{
+        0xff01,
+        0xff60,
+    }, // Fullwidth Exclamation Ma..Fullwidth Right White Pa
+    [2]u21{
+        0xffe0,
+        0xffe6,
+    }, // Fullwidth Cent Sign     ..Fullwidth Won Sign
+    [2]u21{
+        0x16fe0,
+        0x16fe4,
+    }, // Tangut Iteration Mark   ..
+    [2]u21{
+        0x16ff0,
+        0x16ff1,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x17000,
+        0x187f7,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x18800,
+        0x18cd5,
+    }, // Tangut Component-001    ..
+    [2]u21{
+        0x18d00,
+        0x18d08,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1b000,
+        0x1b11e,
+    }, // Katakana Letter Archaic ..Hentaigana Letter N-mu-m
+    [2]u21{
+        0x1b150,
+        0x1b152,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1b164,
+        0x1b167,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1b170,
+        0x1b2fb,
+    }, // Nushu Character-1b170   ..Nushu Character-1b2fb
+    [2]u21{
+        0x1f004,
+        0x1f004,
+    }, // Mahjong Tile Red Dragon ..Mahjong Tile Red Dragon
+    [2]u21{
+        0x1f0cf,
+        0x1f0cf,
+    }, // Playing Card Black Joker..Playing Card Black Joker
+    [2]u21{
+        0x1f18e,
+        0x1f18e,
+    }, // Negative Squared Ab     ..Negative Squared Ab
+    [2]u21{
+        0x1f191,
+        0x1f19a,
+    }, // Squared Cl              ..Squared Vs
+    [2]u21{
+        0x1f200,
+        0x1f202,
+    }, // Square Hiragana Hoka    ..Squared Katakana Sa
+    [2]u21{
+        0x1f210,
+        0x1f23b,
+    }, // Squared Cjk Unified Ideo..Squared Cjk Unified Ideo
+    [2]u21{
+        0x1f240,
+        0x1f248,
+    }, // Tortoise Shell Bracketed..Tortoise Shell Bracketed
+    [2]u21{
+        0x1f250,
+        0x1f251,
+    }, // Circled Ideograph Advant..Circled Ideograph Accept
+    [2]u21{
+        0x1f260,
+        0x1f265,
+    }, // Rounded Symbol For Fu   ..Rounded Symbol For Cai
+    [2]u21{
+        0x1f300,
+        0x1f320,
+    }, // Cyclone                 ..Shooting Star
+    [2]u21{
+        0x1f32d,
+        0x1f335,
+    }, // Hot Dog                 ..Cactus
+    [2]u21{
+        0x1f337,
+        0x1f37c,
+    }, // Tulip                   ..Baby Bottle
+    [2]u21{
+        0x1f37e,
+        0x1f393,
+    }, // Bottle With Popping Cork..Graduation Cap
+    [2]u21{
+        0x1f3a0,
+        0x1f3ca,
+    }, // Carousel Horse          ..Swimmer
+    [2]u21{
+        0x1f3cf,
+        0x1f3d3,
+    }, // Cricket Bat And Ball    ..Table Tennis Paddle And
+    [2]u21{
+        0x1f3e0,
+        0x1f3f0,
+    }, // House Building          ..European Castle
+    [2]u21{
+        0x1f3f4,
+        0x1f3f4,
+    }, // Waving Black Flag       ..Waving Black Flag
+    [2]u21{
+        0x1f3f8,
+        0x1f43e,
+    }, // Badminton Racquet And Sh..Paw Prints
+    [2]u21{
+        0x1f440,
+        0x1f440,
+    }, // Eyes                    ..Eyes
+    [2]u21{
+        0x1f442,
+        0x1f4fc,
+    }, // Ear                     ..Videocassette
+    [2]u21{
+        0x1f4ff,
+        0x1f53d,
+    }, // Prayer Beads            ..Down-pointing Small Red
+    [2]u21{
+        0x1f54b,
+        0x1f54e,
+    }, // Kaaba                   ..Menorah With Nine Branch
+    [2]u21{
+        0x1f550,
+        0x1f567,
+    }, // Clock Face One Oclock   ..Clock Face Twelve-thirty
+    [2]u21{
+        0x1f57a,
+        0x1f57a,
+    }, // Man Dancing             ..Man Dancing
+    [2]u21{
+        0x1f595,
+        0x1f596,
+    }, // Reversed Hand With Middl..Raised Hand With Part Be
+    [2]u21{
+        0x1f5a4,
+        0x1f5a4,
+    }, // Black Heart             ..Black Heart
+    [2]u21{
+        0x1f5fb,
+        0x1f64f,
+    }, // Mount Fuji              ..Person With Folded Hands
+    [2]u21{
+        0x1f680,
+        0x1f6c5,
+    }, // Rocket                  ..Left Luggage
+    [2]u21{
+        0x1f6cc,
+        0x1f6cc,
+    }, // Sleeping Accommodation  ..Sleeping Accommodation
+    [2]u21{
+        0x1f6d0,
+        0x1f6d2,
+    }, // Place Of Worship        ..Shopping Trolley
+    [2]u21{
+        0x1f6d5,
+        0x1f6d7,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1f6eb,
+        0x1f6ec,
+    }, // Airplane Departure      ..Airplane Arriving
+    [2]u21{
+        0x1f6f4,
+        0x1f6fc,
+    }, // Scooter                 ..
+    [2]u21{
+        0x1f7e0,
+        0x1f7eb,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1f90c,
+        0x1f93a,
+    }, // [2]u21{ nil }                   ..Fencer
+    [2]u21{
+        0x1f93c,
+        0x1f945,
+    }, // Wrestlers               ..Goal Net
+    [2]u21{
+        0x1f947,
+        0x1f978,
+    }, // First Place Medal       ..
+    [2]u21{
+        0x1f97a,
+        0x1f9cb,
+    }, // Face With Pleading Eyes ..
+    [2]u21{
+        0x1f9cd,
+        0x1f9ff,
+    }, // [2]u21{ nil }                   ..Nazar Amulet
+    [2]u21{
+        0x1fa70,
+        0x1fa74,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fa78,
+        0x1fa7a,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fa80,
+        0x1fa86,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fa90,
+        0x1faa8,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fab0,
+        0x1fab6,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fac0,
+        0x1fac2,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1fad0,
+        0x1fad6,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x20000,
+        0x2fffd,
+    }, // Cjk Unified Ideograph-20..
+    [2]u21{
+        0x30000,
+        0x3fffd,
+    }, // [2]u21{ nil }                   ..
+};

--- a/lib/linenoize/src/zig-wcwidth/src/table_zero.zig
+++ b/lib/linenoize/src/zig-wcwidth/src/table_zero.zig
@@ -1,0 +1,1298 @@
+pub const zero_width = [_][2]u21{
+    [2]u21{
+        0x0300,
+        0x036f,
+    }, // Combining Grave Accent  ..Combining Latin Small Le
+    [2]u21{
+        0x0483,
+        0x0489,
+    }, // Combining Cyrillic Titlo..Combining Cyrillic Milli
+    [2]u21{
+        0x0591,
+        0x05bd,
+    }, // Hebrew Accent Etnahta   ..Hebrew Point Meteg
+    [2]u21{
+        0x05bf,
+        0x05bf,
+    }, // Hebrew Point Rafe       ..Hebrew Point Rafe
+    [2]u21{
+        0x05c1,
+        0x05c2,
+    }, // Hebrew Point Shin Dot   ..Hebrew Point Sin Dot
+    [2]u21{
+        0x05c4,
+        0x05c5,
+    }, // Hebrew Mark Upper Dot   ..Hebrew Mark Lower Dot
+    [2]u21{
+        0x05c7,
+        0x05c7,
+    }, // Hebrew Point Qamats Qata..Hebrew Point Qamats Qata
+    [2]u21{
+        0x0610,
+        0x061a,
+    }, // Arabic Sign Sallallahou ..Arabic Small Kasra
+    [2]u21{
+        0x064b,
+        0x065f,
+    }, // Arabic Fathatan         ..Arabic Wavy Hamza Below
+    [2]u21{
+        0x0670,
+        0x0670,
+    }, // Arabic Letter Superscrip..Arabic Letter Superscrip
+    [2]u21{
+        0x06d6,
+        0x06dc,
+    }, // Arabic Small High Ligatu..Arabic Small High Seen
+    [2]u21{
+        0x06df,
+        0x06e4,
+    }, // Arabic Small High Rounde..Arabic Small High Madda
+    [2]u21{
+        0x06e7,
+        0x06e8,
+    }, // Arabic Small High Yeh   ..Arabic Small High Noon
+    [2]u21{
+        0x06ea,
+        0x06ed,
+    }, // Arabic Empty Centre Low ..Arabic Small Low Meem
+    [2]u21{
+        0x0711,
+        0x0711,
+    }, // Syriac Letter Superscrip..Syriac Letter Superscrip
+    [2]u21{
+        0x0730,
+        0x074a,
+    }, // Syriac Pthaha Above     ..Syriac Barrekh
+    [2]u21{
+        0x07a6,
+        0x07b0,
+    }, // Thaana Abafili          ..Thaana Sukun
+    [2]u21{
+        0x07eb,
+        0x07f3,
+    }, // Nko Combining Short High..Nko Combining Double Dot
+    [2]u21{
+        0x07fd,
+        0x07fd,
+    }, // Nko Dantayalan          ..Nko Dantayalan
+    [2]u21{
+        0x0816,
+        0x0819,
+    }, // Samaritan Mark In       ..Samaritan Mark Dagesh
+    [2]u21{
+        0x081b,
+        0x0823,
+    }, // Samaritan Mark Epentheti..Samaritan Vowel Sign A
+    [2]u21{
+        0x0825,
+        0x0827,
+    }, // Samaritan Vowel Sign Sho..Samaritan Vowel Sign U
+    [2]u21{
+        0x0829,
+        0x082d,
+    }, // Samaritan Vowel Sign Lon..Samaritan Mark Nequdaa
+    [2]u21{
+        0x0859,
+        0x085b,
+    }, // Mandaic Affrication Mark..Mandaic Gemination Mark
+    [2]u21{
+        0x08d3,
+        0x08e1,
+    }, // Arabic Small Low Waw    ..Arabic Small High Sign S
+    [2]u21{
+        0x08e3,
+        0x0902,
+    }, // Arabic Turned Damma Belo..Devanagari Sign Anusvara
+    [2]u21{
+        0x093a,
+        0x093a,
+    }, // Devanagari Vowel Sign Oe..Devanagari Vowel Sign Oe
+    [2]u21{
+        0x093c,
+        0x093c,
+    }, // Devanagari Sign Nukta   ..Devanagari Sign Nukta
+    [2]u21{
+        0x0941,
+        0x0948,
+    }, // Devanagari Vowel Sign U ..Devanagari Vowel Sign Ai
+    [2]u21{
+        0x094d,
+        0x094d,
+    }, // Devanagari Sign Virama  ..Devanagari Sign Virama
+    [2]u21{
+        0x0951,
+        0x0957,
+    }, // Devanagari Stress Sign U..Devanagari Vowel Sign Uu
+    [2]u21{
+        0x0962,
+        0x0963,
+    }, // Devanagari Vowel Sign Vo..Devanagari Vowel Sign Vo
+    [2]u21{
+        0x0981,
+        0x0981,
+    }, // Bengali Sign Candrabindu..Bengali Sign Candrabindu
+    [2]u21{
+        0x09bc,
+        0x09bc,
+    }, // Bengali Sign Nukta      ..Bengali Sign Nukta
+    [2]u21{
+        0x09c1,
+        0x09c4,
+    }, // Bengali Vowel Sign U    ..Bengali Vowel Sign Vocal
+    [2]u21{
+        0x09cd,
+        0x09cd,
+    }, // Bengali Sign Virama     ..Bengali Sign Virama
+    [2]u21{
+        0x09e2,
+        0x09e3,
+    }, // Bengali Vowel Sign Vocal..Bengali Vowel Sign Vocal
+    [2]u21{
+        0x09fe,
+        0x09fe,
+    }, // Bengali Sandhi Mark     ..Bengali Sandhi Mark
+    [2]u21{
+        0x0a01,
+        0x0a02,
+    }, // Gurmukhi Sign Adak Bindi..Gurmukhi Sign Bindi
+    [2]u21{
+        0x0a3c,
+        0x0a3c,
+    }, // Gurmukhi Sign Nukta     ..Gurmukhi Sign Nukta
+    [2]u21{
+        0x0a41,
+        0x0a42,
+    }, // Gurmukhi Vowel Sign U   ..Gurmukhi Vowel Sign Uu
+    [2]u21{
+        0x0a47,
+        0x0a48,
+    }, // Gurmukhi Vowel Sign Ee  ..Gurmukhi Vowel Sign Ai
+    [2]u21{
+        0x0a4b,
+        0x0a4d,
+    }, // Gurmukhi Vowel Sign Oo  ..Gurmukhi Sign Virama
+    [2]u21{
+        0x0a51,
+        0x0a51,
+    }, // Gurmukhi Sign Udaat     ..Gurmukhi Sign Udaat
+    [2]u21{
+        0x0a70,
+        0x0a71,
+    }, // Gurmukhi Tippi          ..Gurmukhi Addak
+    [2]u21{
+        0x0a75,
+        0x0a75,
+    }, // Gurmukhi Sign Yakash    ..Gurmukhi Sign Yakash
+    [2]u21{
+        0x0a81,
+        0x0a82,
+    }, // Gujarati Sign Candrabind..Gujarati Sign Anusvara
+    [2]u21{
+        0x0abc,
+        0x0abc,
+    }, // Gujarati Sign Nukta     ..Gujarati Sign Nukta
+    [2]u21{
+        0x0ac1,
+        0x0ac5,
+    }, // Gujarati Vowel Sign U   ..Gujarati Vowel Sign Cand
+    [2]u21{
+        0x0ac7,
+        0x0ac8,
+    }, // Gujarati Vowel Sign E   ..Gujarati Vowel Sign Ai
+    [2]u21{
+        0x0acd,
+        0x0acd,
+    }, // Gujarati Sign Virama    ..Gujarati Sign Virama
+    [2]u21{
+        0x0ae2,
+        0x0ae3,
+    }, // Gujarati Vowel Sign Voca..Gujarati Vowel Sign Voca
+    [2]u21{
+        0x0afa,
+        0x0aff,
+    }, // Gujarati Sign Sukun     ..Gujarati Sign Two-circle
+    [2]u21{
+        0x0b01,
+        0x0b01,
+    }, // Oriya Sign Candrabindu  ..Oriya Sign Candrabindu
+    [2]u21{
+        0x0b3c,
+        0x0b3c,
+    }, // Oriya Sign Nukta        ..Oriya Sign Nukta
+    [2]u21{
+        0x0b3f,
+        0x0b3f,
+    }, // Oriya Vowel Sign I      ..Oriya Vowel Sign I
+    [2]u21{
+        0x0b41,
+        0x0b44,
+    }, // Oriya Vowel Sign U      ..Oriya Vowel Sign Vocalic
+    [2]u21{
+        0x0b4d,
+        0x0b4d,
+    }, // Oriya Sign Virama       ..Oriya Sign Virama
+    [2]u21{
+        0x0b55,
+        0x0b56,
+    }, // [2]u21{ nil }                   ..Oriya Ai Length Mark
+    [2]u21{
+        0x0b62,
+        0x0b63,
+    }, // Oriya Vowel Sign Vocalic..Oriya Vowel Sign Vocalic
+    [2]u21{
+        0x0b82,
+        0x0b82,
+    }, // Tamil Sign Anusvara     ..Tamil Sign Anusvara
+    [2]u21{
+        0x0bc0,
+        0x0bc0,
+    }, // Tamil Vowel Sign Ii     ..Tamil Vowel Sign Ii
+    [2]u21{
+        0x0bcd,
+        0x0bcd,
+    }, // Tamil Sign Virama       ..Tamil Sign Virama
+    [2]u21{
+        0x0c00,
+        0x0c00,
+    }, // Telugu Sign Combining Ca..Telugu Sign Combining Ca
+    [2]u21{
+        0x0c04,
+        0x0c04,
+    }, // Telugu Sign Combining An..Telugu Sign Combining An
+    [2]u21{
+        0x0c3e,
+        0x0c40,
+    }, // Telugu Vowel Sign Aa    ..Telugu Vowel Sign Ii
+    [2]u21{
+        0x0c46,
+        0x0c48,
+    }, // Telugu Vowel Sign E     ..Telugu Vowel Sign Ai
+    [2]u21{
+        0x0c4a,
+        0x0c4d,
+    }, // Telugu Vowel Sign O     ..Telugu Sign Virama
+    [2]u21{
+        0x0c55,
+        0x0c56,
+    }, // Telugu Length Mark      ..Telugu Ai Length Mark
+    [2]u21{
+        0x0c62,
+        0x0c63,
+    }, // Telugu Vowel Sign Vocali..Telugu Vowel Sign Vocali
+    [2]u21{
+        0x0c81,
+        0x0c81,
+    }, // Kannada Sign Candrabindu..Kannada Sign Candrabindu
+    [2]u21{
+        0x0cbc,
+        0x0cbc,
+    }, // Kannada Sign Nukta      ..Kannada Sign Nukta
+    [2]u21{
+        0x0cbf,
+        0x0cbf,
+    }, // Kannada Vowel Sign I    ..Kannada Vowel Sign I
+    [2]u21{
+        0x0cc6,
+        0x0cc6,
+    }, // Kannada Vowel Sign E    ..Kannada Vowel Sign E
+    [2]u21{
+        0x0ccc,
+        0x0ccd,
+    }, // Kannada Vowel Sign Au   ..Kannada Sign Virama
+    [2]u21{
+        0x0ce2,
+        0x0ce3,
+    }, // Kannada Vowel Sign Vocal..Kannada Vowel Sign Vocal
+    [2]u21{
+        0x0d00,
+        0x0d01,
+    }, // Malayalam Sign Combining..Malayalam Sign Candrabin
+    [2]u21{
+        0x0d3b,
+        0x0d3c,
+    }, // Malayalam Sign Vertical ..Malayalam Sign Circular
+    [2]u21{
+        0x0d41,
+        0x0d44,
+    }, // Malayalam Vowel Sign U  ..Malayalam Vowel Sign Voc
+    [2]u21{
+        0x0d4d,
+        0x0d4d,
+    }, // Malayalam Sign Virama   ..Malayalam Sign Virama
+    [2]u21{
+        0x0d62,
+        0x0d63,
+    }, // Malayalam Vowel Sign Voc..Malayalam Vowel Sign Voc
+    [2]u21{
+        0x0d81,
+        0x0d81,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x0dca,
+        0x0dca,
+    }, // Sinhala Sign Al-lakuna  ..Sinhala Sign Al-lakuna
+    [2]u21{
+        0x0dd2,
+        0x0dd4,
+    }, // Sinhala Vowel Sign Ketti..Sinhala Vowel Sign Ketti
+    [2]u21{
+        0x0dd6,
+        0x0dd6,
+    }, // Sinhala Vowel Sign Diga ..Sinhala Vowel Sign Diga
+    [2]u21{
+        0x0e31,
+        0x0e31,
+    }, // Thai Character Mai Han-a..Thai Character Mai Han-a
+    [2]u21{
+        0x0e34,
+        0x0e3a,
+    }, // Thai Character Sara I   ..Thai Character Phinthu
+    [2]u21{
+        0x0e47,
+        0x0e4e,
+    }, // Thai Character Maitaikhu..Thai Character Yamakkan
+    [2]u21{
+        0x0eb1,
+        0x0eb1,
+    }, // Lao Vowel Sign Mai Kan  ..Lao Vowel Sign Mai Kan
+    [2]u21{
+        0x0eb4,
+        0x0ebc,
+    }, // Lao Vowel Sign I        ..Lao Semivowel Sign Lo
+    [2]u21{
+        0x0ec8,
+        0x0ecd,
+    }, // Lao Tone Mai Ek         ..Lao Niggahita
+    [2]u21{
+        0x0f18,
+        0x0f19,
+    }, // Tibetan Astrological Sig..Tibetan Astrological Sig
+    [2]u21{
+        0x0f35,
+        0x0f35,
+    }, // Tibetan Mark Ngas Bzung ..Tibetan Mark Ngas Bzung
+    [2]u21{
+        0x0f37,
+        0x0f37,
+    }, // Tibetan Mark Ngas Bzung ..Tibetan Mark Ngas Bzung
+    [2]u21{
+        0x0f39,
+        0x0f39,
+    }, // Tibetan Mark Tsa -phru  ..Tibetan Mark Tsa -phru
+    [2]u21{
+        0x0f71,
+        0x0f7e,
+    }, // Tibetan Vowel Sign Aa   ..Tibetan Sign Rjes Su Nga
+    [2]u21{
+        0x0f80,
+        0x0f84,
+    }, // Tibetan Vowel Sign Rever..Tibetan Mark Halanta
+    [2]u21{
+        0x0f86,
+        0x0f87,
+    }, // Tibetan Sign Lci Rtags  ..Tibetan Sign Yang Rtags
+    [2]u21{
+        0x0f8d,
+        0x0f97,
+    }, // Tibetan Subjoined Sign L..Tibetan Subjoined Letter
+    [2]u21{
+        0x0f99,
+        0x0fbc,
+    }, // Tibetan Subjoined Letter..Tibetan Subjoined Letter
+    [2]u21{
+        0x0fc6,
+        0x0fc6,
+    }, // Tibetan Symbol Padma Gda..Tibetan Symbol Padma Gda
+    [2]u21{
+        0x102d,
+        0x1030,
+    }, // Myanmar Vowel Sign I    ..Myanmar Vowel Sign Uu
+    [2]u21{
+        0x1032,
+        0x1037,
+    }, // Myanmar Vowel Sign Ai   ..Myanmar Sign Dot Below
+    [2]u21{
+        0x1039,
+        0x103a,
+    }, // Myanmar Sign Virama     ..Myanmar Sign Asat
+    [2]u21{
+        0x103d,
+        0x103e,
+    }, // Myanmar Consonant Sign M..Myanmar Consonant Sign M
+    [2]u21{
+        0x1058,
+        0x1059,
+    }, // Myanmar Vowel Sign Vocal..Myanmar Vowel Sign Vocal
+    [2]u21{
+        0x105e,
+        0x1060,
+    }, // Myanmar Consonant Sign M..Myanmar Consonant Sign M
+    [2]u21{
+        0x1071,
+        0x1074,
+    }, // Myanmar Vowel Sign Geba ..Myanmar Vowel Sign Kayah
+    [2]u21{
+        0x1082,
+        0x1082,
+    }, // Myanmar Consonant Sign S..Myanmar Consonant Sign S
+    [2]u21{
+        0x1085,
+        0x1086,
+    }, // Myanmar Vowel Sign Shan ..Myanmar Vowel Sign Shan
+    [2]u21{
+        0x108d,
+        0x108d,
+    }, // Myanmar Sign Shan Counci..Myanmar Sign Shan Counci
+    [2]u21{
+        0x109d,
+        0x109d,
+    }, // Myanmar Vowel Sign Aiton..Myanmar Vowel Sign Aiton
+    [2]u21{
+        0x135d,
+        0x135f,
+    }, // Ethiopic Combining Gemin..Ethiopic Combining Gemin
+    [2]u21{
+        0x1712,
+        0x1714,
+    }, // Tagalog Vowel Sign I    ..Tagalog Sign Virama
+    [2]u21{
+        0x1732,
+        0x1734,
+    }, // Hanunoo Vowel Sign I    ..Hanunoo Sign Pamudpod
+    [2]u21{
+        0x1752,
+        0x1753,
+    }, // Buhid Vowel Sign I      ..Buhid Vowel Sign U
+    [2]u21{
+        0x1772,
+        0x1773,
+    }, // Tagbanwa Vowel Sign I   ..Tagbanwa Vowel Sign U
+    [2]u21{
+        0x17b4,
+        0x17b5,
+    }, // Khmer Vowel Inherent Aq ..Khmer Vowel Inherent Aa
+    [2]u21{
+        0x17b7,
+        0x17bd,
+    }, // Khmer Vowel Sign I      ..Khmer Vowel Sign Ua
+    [2]u21{
+        0x17c6,
+        0x17c6,
+    }, // Khmer Sign Nikahit      ..Khmer Sign Nikahit
+    [2]u21{
+        0x17c9,
+        0x17d3,
+    }, // Khmer Sign Muusikatoan  ..Khmer Sign Bathamasat
+    [2]u21{
+        0x17dd,
+        0x17dd,
+    }, // Khmer Sign Atthacan     ..Khmer Sign Atthacan
+    [2]u21{
+        0x180b,
+        0x180d,
+    }, // Mongolian Free Variation..Mongolian Free Variation
+    [2]u21{
+        0x1885,
+        0x1886,
+    }, // Mongolian Letter Ali Gal..Mongolian Letter Ali Gal
+    [2]u21{
+        0x18a9,
+        0x18a9,
+    }, // Mongolian Letter Ali Gal..Mongolian Letter Ali Gal
+    [2]u21{
+        0x1920,
+        0x1922,
+    }, // Limbu Vowel Sign A      ..Limbu Vowel Sign U
+    [2]u21{
+        0x1927,
+        0x1928,
+    }, // Limbu Vowel Sign E      ..Limbu Vowel Sign O
+    [2]u21{
+        0x1932,
+        0x1932,
+    }, // Limbu Small Letter Anusv..Limbu Small Letter Anusv
+    [2]u21{
+        0x1939,
+        0x193b,
+    }, // Limbu Sign Mukphreng    ..Limbu Sign Sa-i
+    [2]u21{
+        0x1a17,
+        0x1a18,
+    }, // Buginese Vowel Sign I   ..Buginese Vowel Sign U
+    [2]u21{
+        0x1a1b,
+        0x1a1b,
+    }, // Buginese Vowel Sign Ae  ..Buginese Vowel Sign Ae
+    [2]u21{
+        0x1a56,
+        0x1a56,
+    }, // Tai Tham Consonant Sign ..Tai Tham Consonant Sign
+    [2]u21{
+        0x1a58,
+        0x1a5e,
+    }, // Tai Tham Sign Mai Kang L..Tai Tham Consonant Sign
+    [2]u21{
+        0x1a60,
+        0x1a60,
+    }, // Tai Tham Sign Sakot     ..Tai Tham Sign Sakot
+    [2]u21{
+        0x1a62,
+        0x1a62,
+    }, // Tai Tham Vowel Sign Mai ..Tai Tham Vowel Sign Mai
+    [2]u21{
+        0x1a65,
+        0x1a6c,
+    }, // Tai Tham Vowel Sign I   ..Tai Tham Vowel Sign Oa B
+    [2]u21{
+        0x1a73,
+        0x1a7c,
+    }, // Tai Tham Vowel Sign Oa A..Tai Tham Sign Khuen-lue
+    [2]u21{
+        0x1a7f,
+        0x1a7f,
+    }, // Tai Tham Combining Crypt..Tai Tham Combining Crypt
+    [2]u21{
+        0x1ab0,
+        0x1ac0,
+    }, // Combining Doubled Circum..
+    [2]u21{
+        0x1b00,
+        0x1b03,
+    }, // Balinese Sign Ulu Ricem ..Balinese Sign Surang
+    [2]u21{
+        0x1b34,
+        0x1b34,
+    }, // Balinese Sign Rerekan   ..Balinese Sign Rerekan
+    [2]u21{
+        0x1b36,
+        0x1b3a,
+    }, // Balinese Vowel Sign Ulu ..Balinese Vowel Sign Ra R
+    [2]u21{
+        0x1b3c,
+        0x1b3c,
+    }, // Balinese Vowel Sign La L..Balinese Vowel Sign La L
+    [2]u21{
+        0x1b42,
+        0x1b42,
+    }, // Balinese Vowel Sign Pepe..Balinese Vowel Sign Pepe
+    [2]u21{
+        0x1b6b,
+        0x1b73,
+    }, // Balinese Musical Symbol ..Balinese Musical Symbol
+    [2]u21{
+        0x1b80,
+        0x1b81,
+    }, // Sundanese Sign Panyecek ..Sundanese Sign Panglayar
+    [2]u21{
+        0x1ba2,
+        0x1ba5,
+    }, // Sundanese Consonant Sign..Sundanese Vowel Sign Pan
+    [2]u21{
+        0x1ba8,
+        0x1ba9,
+    }, // Sundanese Vowel Sign Pam..Sundanese Vowel Sign Pan
+    [2]u21{
+        0x1bab,
+        0x1bad,
+    }, // Sundanese Sign Virama   ..Sundanese Consonant Sign
+    [2]u21{
+        0x1be6,
+        0x1be6,
+    }, // Batak Sign Tompi        ..Batak Sign Tompi
+    [2]u21{
+        0x1be8,
+        0x1be9,
+    }, // Batak Vowel Sign Pakpak ..Batak Vowel Sign Ee
+    [2]u21{
+        0x1bed,
+        0x1bed,
+    }, // Batak Vowel Sign Karo O ..Batak Vowel Sign Karo O
+    [2]u21{
+        0x1bef,
+        0x1bf1,
+    }, // Batak Vowel Sign U For S..Batak Consonant Sign H
+    [2]u21{
+        0x1c2c,
+        0x1c33,
+    }, // Lepcha Vowel Sign E     ..Lepcha Consonant Sign T
+    [2]u21{
+        0x1c36,
+        0x1c37,
+    }, // Lepcha Sign Ran         ..Lepcha Sign Nukta
+    [2]u21{
+        0x1cd0,
+        0x1cd2,
+    }, // Vedic Tone Karshana     ..Vedic Tone Prenkha
+    [2]u21{
+        0x1cd4,
+        0x1ce0,
+    }, // Vedic Sign Yajurvedic Mi..Vedic Tone Rigvedic Kash
+    [2]u21{
+        0x1ce2,
+        0x1ce8,
+    }, // Vedic Sign Visarga Svari..Vedic Sign Visarga Anuda
+    [2]u21{
+        0x1ced,
+        0x1ced,
+    }, // Vedic Sign Tiryak       ..Vedic Sign Tiryak
+    [2]u21{
+        0x1cf4,
+        0x1cf4,
+    }, // Vedic Tone Candra Above ..Vedic Tone Candra Above
+    [2]u21{
+        0x1cf8,
+        0x1cf9,
+    }, // Vedic Tone Ring Above   ..Vedic Tone Double Ring A
+    [2]u21{
+        0x1dc0,
+        0x1df9,
+    }, // Combining Dotted Grave A..Combining Wide Inverted
+    [2]u21{
+        0x1dfb,
+        0x1dff,
+    }, // Combining Deletion Mark ..Combining Right Arrowhea
+    [2]u21{
+        0x20d0,
+        0x20f0,
+    }, // Combining Left Harpoon A..Combining Asterisk Above
+    [2]u21{
+        0x2cef,
+        0x2cf1,
+    }, // Coptic Combining Ni Abov..Coptic Combining Spiritu
+    [2]u21{
+        0x2d7f,
+        0x2d7f,
+    }, // Tifinagh Consonant Joine..Tifinagh Consonant Joine
+    [2]u21{
+        0x2de0,
+        0x2dff,
+    }, // Combining Cyrillic Lette..Combining Cyrillic Lette
+    [2]u21{
+        0x302a,
+        0x302d,
+    }, // Ideographic Level Tone M..Ideographic Entering Ton
+    [2]u21{
+        0x3099,
+        0x309a,
+    }, // Combining Katakana-hirag..Combining Katakana-hirag
+    [2]u21{
+        0xa66f,
+        0xa672,
+    }, // Combining Cyrillic Vzmet..Combining Cyrillic Thous
+    [2]u21{
+        0xa674,
+        0xa67d,
+    }, // Combining Cyrillic Lette..Combining Cyrillic Payer
+    [2]u21{
+        0xa69e,
+        0xa69f,
+    }, // Combining Cyrillic Lette..Combining Cyrillic Lette
+    [2]u21{
+        0xa6f0,
+        0xa6f1,
+    }, // Bamum Combining Mark Koq..Bamum Combining Mark Tuk
+    [2]u21{
+        0xa802,
+        0xa802,
+    }, // Syloti Nagri Sign Dvisva..Syloti Nagri Sign Dvisva
+    [2]u21{
+        0xa806,
+        0xa806,
+    }, // Syloti Nagri Sign Hasant..Syloti Nagri Sign Hasant
+    [2]u21{
+        0xa80b,
+        0xa80b,
+    }, // Syloti Nagri Sign Anusva..Syloti Nagri Sign Anusva
+    [2]u21{
+        0xa825,
+        0xa826,
+    }, // Syloti Nagri Vowel Sign ..Syloti Nagri Vowel Sign
+    [2]u21{
+        0xa82c,
+        0xa82c,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0xa8c4,
+        0xa8c5,
+    }, // Saurashtra Sign Virama  ..Saurashtra Sign Candrabi
+    [2]u21{
+        0xa8e0,
+        0xa8f1,
+    }, // Combining Devanagari Dig..Combining Devanagari Sig
+    [2]u21{
+        0xa8ff,
+        0xa8ff,
+    }, // Devanagari Vowel Sign Ay..Devanagari Vowel Sign Ay
+    [2]u21{
+        0xa926,
+        0xa92d,
+    }, // Kayah Li Vowel Ue       ..Kayah Li Tone Calya Plop
+    [2]u21{
+        0xa947,
+        0xa951,
+    }, // Rejang Vowel Sign I     ..Rejang Consonant Sign R
+    [2]u21{
+        0xa980,
+        0xa982,
+    }, // Javanese Sign Panyangga ..Javanese Sign Layar
+    [2]u21{
+        0xa9b3,
+        0xa9b3,
+    }, // Javanese Sign Cecak Telu..Javanese Sign Cecak Telu
+    [2]u21{
+        0xa9b6,
+        0xa9b9,
+    }, // Javanese Vowel Sign Wulu..Javanese Vowel Sign Suku
+    [2]u21{
+        0xa9bc,
+        0xa9bd,
+    }, // Javanese Vowel Sign Pepe..Javanese Consonant Sign
+    [2]u21{
+        0xa9e5,
+        0xa9e5,
+    }, // Myanmar Sign Shan Saw   ..Myanmar Sign Shan Saw
+    [2]u21{
+        0xaa29,
+        0xaa2e,
+    }, // Cham Vowel Sign Aa      ..Cham Vowel Sign Oe
+    [2]u21{
+        0xaa31,
+        0xaa32,
+    }, // Cham Vowel Sign Au      ..Cham Vowel Sign Ue
+    [2]u21{
+        0xaa35,
+        0xaa36,
+    }, // Cham Consonant Sign La  ..Cham Consonant Sign Wa
+    [2]u21{
+        0xaa43,
+        0xaa43,
+    }, // Cham Consonant Sign Fina..Cham Consonant Sign Fina
+    [2]u21{
+        0xaa4c,
+        0xaa4c,
+    }, // Cham Consonant Sign Fina..Cham Consonant Sign Fina
+    [2]u21{
+        0xaa7c,
+        0xaa7c,
+    }, // Myanmar Sign Tai Laing T..Myanmar Sign Tai Laing T
+    [2]u21{
+        0xaab0,
+        0xaab0,
+    }, // Tai Viet Mai Kang       ..Tai Viet Mai Kang
+    [2]u21{
+        0xaab2,
+        0xaab4,
+    }, // Tai Viet Vowel I        ..Tai Viet Vowel U
+    [2]u21{
+        0xaab7,
+        0xaab8,
+    }, // Tai Viet Mai Khit       ..Tai Viet Vowel Ia
+    [2]u21{
+        0xaabe,
+        0xaabf,
+    }, // Tai Viet Vowel Am       ..Tai Viet Tone Mai Ek
+    [2]u21{
+        0xaac1,
+        0xaac1,
+    }, // Tai Viet Tone Mai Tho   ..Tai Viet Tone Mai Tho
+    [2]u21{
+        0xaaec,
+        0xaaed,
+    }, // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+    [2]u21{
+        0xaaf6,
+        0xaaf6,
+    }, // Meetei Mayek Virama     ..Meetei Mayek Virama
+    [2]u21{
+        0xabe5,
+        0xabe5,
+    }, // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+    [2]u21{
+        0xabe8,
+        0xabe8,
+    }, // Meetei Mayek Vowel Sign ..Meetei Mayek Vowel Sign
+    [2]u21{
+        0xabed,
+        0xabed,
+    }, // Meetei Mayek Apun Iyek  ..Meetei Mayek Apun Iyek
+    [2]u21{
+        0xfb1e,
+        0xfb1e,
+    }, // Hebrew Point Judeo-spani..Hebrew Point Judeo-spani
+    [2]u21{
+        0xfe00,
+        0xfe0f,
+    }, // Variation Selector-1    ..Variation Selector-16
+    [2]u21{
+        0xfe20,
+        0xfe2f,
+    }, // Combining Ligature Left ..Combining Cyrillic Titlo
+    [2]u21{
+        0x101fd,
+        0x101fd,
+    }, // Phaistos Disc Sign Combi..Phaistos Disc Sign Combi
+    [2]u21{
+        0x102e0,
+        0x102e0,
+    }, // Coptic Epact Thousands M..Coptic Epact Thousands M
+    [2]u21{
+        0x10376,
+        0x1037a,
+    }, // Combining Old Permic Let..Combining Old Permic Let
+    [2]u21{
+        0x10a01,
+        0x10a03,
+    }, // Kharoshthi Vowel Sign I ..Kharoshthi Vowel Sign Vo
+    [2]u21{
+        0x10a05,
+        0x10a06,
+    }, // Kharoshthi Vowel Sign E ..Kharoshthi Vowel Sign O
+    [2]u21{
+        0x10a0c,
+        0x10a0f,
+    }, // Kharoshthi Vowel Length ..Kharoshthi Sign Visarga
+    [2]u21{
+        0x10a38,
+        0x10a3a,
+    }, // Kharoshthi Sign Bar Abov..Kharoshthi Sign Dot Belo
+    [2]u21{
+        0x10a3f,
+        0x10a3f,
+    }, // Kharoshthi Virama       ..Kharoshthi Virama
+    [2]u21{
+        0x10ae5,
+        0x10ae6,
+    }, // Manichaean Abbreviation ..Manichaean Abbreviation
+    [2]u21{
+        0x10d24,
+        0x10d27,
+    }, // Hanifi Rohingya Sign Har..Hanifi Rohingya Sign Tas
+    [2]u21{
+        0x10eab,
+        0x10eac,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x10f46,
+        0x10f50,
+    }, // Sogdian Combining Dot Be..Sogdian Combining Stroke
+    [2]u21{
+        0x11001,
+        0x11001,
+    }, // Brahmi Sign Anusvara    ..Brahmi Sign Anusvara
+    [2]u21{
+        0x11038,
+        0x11046,
+    }, // Brahmi Vowel Sign Aa    ..Brahmi Virama
+    [2]u21{
+        0x1107f,
+        0x11081,
+    }, // Brahmi Number Joiner    ..Kaithi Sign Anusvara
+    [2]u21{
+        0x110b3,
+        0x110b6,
+    }, // Kaithi Vowel Sign U     ..Kaithi Vowel Sign Ai
+    [2]u21{
+        0x110b9,
+        0x110ba,
+    }, // Kaithi Sign Virama      ..Kaithi Sign Nukta
+    [2]u21{
+        0x11100,
+        0x11102,
+    }, // Chakma Sign Candrabindu ..Chakma Sign Visarga
+    [2]u21{
+        0x11127,
+        0x1112b,
+    }, // Chakma Vowel Sign A     ..Chakma Vowel Sign Uu
+    [2]u21{
+        0x1112d,
+        0x11134,
+    }, // Chakma Vowel Sign Ai    ..Chakma Maayyaa
+    [2]u21{
+        0x11173,
+        0x11173,
+    }, // Mahajani Sign Nukta     ..Mahajani Sign Nukta
+    [2]u21{
+        0x11180,
+        0x11181,
+    }, // Sharada Sign Candrabindu..Sharada Sign Anusvara
+    [2]u21{
+        0x111b6,
+        0x111be,
+    }, // Sharada Vowel Sign U    ..Sharada Vowel Sign O
+    [2]u21{
+        0x111c9,
+        0x111cc,
+    }, // Sharada Sandhi Mark     ..Sharada Extra Short Vowe
+    [2]u21{
+        0x111cf,
+        0x111cf,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1122f,
+        0x11231,
+    }, // Khojki Vowel Sign U     ..Khojki Vowel Sign Ai
+    [2]u21{
+        0x11234,
+        0x11234,
+    }, // Khojki Sign Anusvara    ..Khojki Sign Anusvara
+    [2]u21{
+        0x11236,
+        0x11237,
+    }, // Khojki Sign Nukta       ..Khojki Sign Shadda
+    [2]u21{
+        0x1123e,
+        0x1123e,
+    }, // Khojki Sign Sukun       ..Khojki Sign Sukun
+    [2]u21{
+        0x112df,
+        0x112df,
+    }, // Khudawadi Sign Anusvara ..Khudawadi Sign Anusvara
+    [2]u21{
+        0x112e3,
+        0x112ea,
+    }, // Khudawadi Vowel Sign U  ..Khudawadi Sign Virama
+    [2]u21{
+        0x11300,
+        0x11301,
+    }, // Grantha Sign Combining A..Grantha Sign Candrabindu
+    [2]u21{
+        0x1133b,
+        0x1133c,
+    }, // Combining Bindu Below   ..Grantha Sign Nukta
+    [2]u21{
+        0x11340,
+        0x11340,
+    }, // Grantha Vowel Sign Ii   ..Grantha Vowel Sign Ii
+    [2]u21{
+        0x11366,
+        0x1136c,
+    }, // Combining Grantha Digit ..Combining Grantha Digit
+    [2]u21{
+        0x11370,
+        0x11374,
+    }, // Combining Grantha Letter..Combining Grantha Letter
+    [2]u21{
+        0x11438,
+        0x1143f,
+    }, // Newa Vowel Sign U       ..Newa Vowel Sign Ai
+    [2]u21{
+        0x11442,
+        0x11444,
+    }, // Newa Sign Virama        ..Newa Sign Anusvara
+    [2]u21{
+        0x11446,
+        0x11446,
+    }, // Newa Sign Nukta         ..Newa Sign Nukta
+    [2]u21{
+        0x1145e,
+        0x1145e,
+    }, // Newa Sandhi Mark        ..Newa Sandhi Mark
+    [2]u21{
+        0x114b3,
+        0x114b8,
+    }, // Tirhuta Vowel Sign U    ..Tirhuta Vowel Sign Vocal
+    [2]u21{
+        0x114ba,
+        0x114ba,
+    }, // Tirhuta Vowel Sign Short..Tirhuta Vowel Sign Short
+    [2]u21{
+        0x114bf,
+        0x114c0,
+    }, // Tirhuta Sign Candrabindu..Tirhuta Sign Anusvara
+    [2]u21{
+        0x114c2,
+        0x114c3,
+    }, // Tirhuta Sign Virama     ..Tirhuta Sign Nukta
+    [2]u21{
+        0x115b2,
+        0x115b5,
+    }, // Siddham Vowel Sign U    ..Siddham Vowel Sign Vocal
+    [2]u21{
+        0x115bc,
+        0x115bd,
+    }, // Siddham Sign Candrabindu..Siddham Sign Anusvara
+    [2]u21{
+        0x115bf,
+        0x115c0,
+    }, // Siddham Sign Virama     ..Siddham Sign Nukta
+    [2]u21{
+        0x115dc,
+        0x115dd,
+    }, // Siddham Vowel Sign Alter..Siddham Vowel Sign Alter
+    [2]u21{
+        0x11633,
+        0x1163a,
+    }, // Modi Vowel Sign U       ..Modi Vowel Sign Ai
+    [2]u21{
+        0x1163d,
+        0x1163d,
+    }, // Modi Sign Anusvara      ..Modi Sign Anusvara
+    [2]u21{
+        0x1163f,
+        0x11640,
+    }, // Modi Sign Virama        ..Modi Sign Ardhacandra
+    [2]u21{
+        0x116ab,
+        0x116ab,
+    }, // Takri Sign Anusvara     ..Takri Sign Anusvara
+    [2]u21{
+        0x116ad,
+        0x116ad,
+    }, // Takri Vowel Sign Aa     ..Takri Vowel Sign Aa
+    [2]u21{
+        0x116b0,
+        0x116b5,
+    }, // Takri Vowel Sign U      ..Takri Vowel Sign Au
+    [2]u21{
+        0x116b7,
+        0x116b7,
+    }, // Takri Sign Nukta        ..Takri Sign Nukta
+    [2]u21{
+        0x1171d,
+        0x1171f,
+    }, // Ahom Consonant Sign Medi..Ahom Consonant Sign Medi
+    [2]u21{
+        0x11722,
+        0x11725,
+    }, // Ahom Vowel Sign I       ..Ahom Vowel Sign Uu
+    [2]u21{
+        0x11727,
+        0x1172b,
+    }, // Ahom Vowel Sign Aw      ..Ahom Sign Killer
+    [2]u21{
+        0x1182f,
+        0x11837,
+    }, // Dogra Vowel Sign U      ..Dogra Sign Anusvara
+    [2]u21{
+        0x11839,
+        0x1183a,
+    }, // Dogra Sign Virama       ..Dogra Sign Nukta
+    [2]u21{
+        0x1193b,
+        0x1193c,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1193e,
+        0x1193e,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x11943,
+        0x11943,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x119d4,
+        0x119d7,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x119da,
+        0x119db,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x119e0,
+        0x119e0,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x11a01,
+        0x11a0a,
+    }, // Zanabazar Square Vowel S..Zanabazar Square Vowel L
+    [2]u21{
+        0x11a33,
+        0x11a38,
+    }, // Zanabazar Square Final C..Zanabazar Square Sign An
+    [2]u21{
+        0x11a3b,
+        0x11a3e,
+    }, // Zanabazar Square Cluster..Zanabazar Square Cluster
+    [2]u21{
+        0x11a47,
+        0x11a47,
+    }, // Zanabazar Square Subjoin..Zanabazar Square Subjoin
+    [2]u21{
+        0x11a51,
+        0x11a56,
+    }, // Soyombo Vowel Sign I    ..Soyombo Vowel Sign Oe
+    [2]u21{
+        0x11a59,
+        0x11a5b,
+    }, // Soyombo Vowel Sign Vocal..Soyombo Vowel Length Mar
+    [2]u21{
+        0x11a8a,
+        0x11a96,
+    }, // Soyombo Final Consonant ..Soyombo Sign Anusvara
+    [2]u21{
+        0x11a98,
+        0x11a99,
+    }, // Soyombo Gemination Mark ..Soyombo Subjoiner
+    [2]u21{
+        0x11c30,
+        0x11c36,
+    }, // Bhaiksuki Vowel Sign I  ..Bhaiksuki Vowel Sign Voc
+    [2]u21{
+        0x11c38,
+        0x11c3d,
+    }, // Bhaiksuki Vowel Sign E  ..Bhaiksuki Sign Anusvara
+    [2]u21{
+        0x11c3f,
+        0x11c3f,
+    }, // Bhaiksuki Sign Virama   ..Bhaiksuki Sign Virama
+    [2]u21{
+        0x11c92,
+        0x11ca7,
+    }, // Marchen Subjoined Letter..Marchen Subjoined Letter
+    [2]u21{
+        0x11caa,
+        0x11cb0,
+    }, // Marchen Subjoined Letter..Marchen Vowel Sign Aa
+    [2]u21{
+        0x11cb2,
+        0x11cb3,
+    }, // Marchen Vowel Sign U    ..Marchen Vowel Sign E
+    [2]u21{
+        0x11cb5,
+        0x11cb6,
+    }, // Marchen Sign Anusvara   ..Marchen Sign Candrabindu
+    [2]u21{
+        0x11d31,
+        0x11d36,
+    }, // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+    [2]u21{
+        0x11d3a,
+        0x11d3a,
+    }, // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+    [2]u21{
+        0x11d3c,
+        0x11d3d,
+    }, // Masaram Gondi Vowel Sign..Masaram Gondi Vowel Sign
+    [2]u21{
+        0x11d3f,
+        0x11d45,
+    }, // Masaram Gondi Vowel Sign..Masaram Gondi Virama
+    [2]u21{
+        0x11d47,
+        0x11d47,
+    }, // Masaram Gondi Ra-kara   ..Masaram Gondi Ra-kara
+    [2]u21{
+        0x11d90,
+        0x11d91,
+    }, // Gunjala Gondi Vowel Sign..Gunjala Gondi Vowel Sign
+    [2]u21{
+        0x11d95,
+        0x11d95,
+    }, // Gunjala Gondi Sign Anusv..Gunjala Gondi Sign Anusv
+    [2]u21{
+        0x11d97,
+        0x11d97,
+    }, // Gunjala Gondi Virama    ..Gunjala Gondi Virama
+    [2]u21{
+        0x11ef3,
+        0x11ef4,
+    }, // Makasar Vowel Sign I    ..Makasar Vowel Sign U
+    [2]u21{
+        0x16af0,
+        0x16af4,
+    }, // Bassa Vah Combining High..Bassa Vah Combining High
+    [2]u21{
+        0x16b30,
+        0x16b36,
+    }, // Pahawh Hmong Mark Cim Tu..Pahawh Hmong Mark Cim Ta
+    [2]u21{
+        0x16f4f,
+        0x16f4f,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x16f8f,
+        0x16f92,
+    }, // Miao Tone Right         ..Miao Tone Below
+    [2]u21{
+        0x16fe4,
+        0x16fe4,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1bc9d,
+        0x1bc9e,
+    }, // Duployan Thick Letter Se..Duployan Double Mark
+    [2]u21{
+        0x1d167,
+        0x1d169,
+    }, // Musical Symbol Combining..Musical Symbol Combining
+    [2]u21{
+        0x1d17b,
+        0x1d182,
+    }, // Musical Symbol Combining..Musical Symbol Combining
+    [2]u21{
+        0x1d185,
+        0x1d18b,
+    }, // Musical Symbol Combining..Musical Symbol Combining
+    [2]u21{
+        0x1d1aa,
+        0x1d1ad,
+    }, // Musical Symbol Combining..Musical Symbol Combining
+    [2]u21{
+        0x1d242,
+        0x1d244,
+    }, // Combining Greek Musical ..Combining Greek Musical
+    [2]u21{
+        0x1da00,
+        0x1da36,
+    }, // Signwriting Head Rim    ..Signwriting Air Sucking
+    [2]u21{
+        0x1da3b,
+        0x1da6c,
+    }, // Signwriting Mouth Closed..Signwriting Excitement
+    [2]u21{
+        0x1da75,
+        0x1da75,
+    }, // Signwriting Upper Body T..Signwriting Upper Body T
+    [2]u21{
+        0x1da84,
+        0x1da84,
+    }, // Signwriting Location Hea..Signwriting Location Hea
+    [2]u21{
+        0x1da9b,
+        0x1da9f,
+    }, // Signwriting Fill Modifie..Signwriting Fill Modifie
+    [2]u21{
+        0x1daa1,
+        0x1daaf,
+    }, // Signwriting Rotation Mod..Signwriting Rotation Mod
+    [2]u21{
+        0x1e000,
+        0x1e006,
+    }, // Combining Glagolitic Let..Combining Glagolitic Let
+    [2]u21{
+        0x1e008,
+        0x1e018,
+    }, // Combining Glagolitic Let..Combining Glagolitic Let
+    [2]u21{
+        0x1e01b,
+        0x1e021,
+    }, // Combining Glagolitic Let..Combining Glagolitic Let
+    [2]u21{
+        0x1e023,
+        0x1e024,
+    }, // Combining Glagolitic Let..Combining Glagolitic Let
+    [2]u21{
+        0x1e026,
+        0x1e02a,
+    }, // Combining Glagolitic Let..Combining Glagolitic Let
+    [2]u21{
+        0x1e130,
+        0x1e136,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1e2ec,
+        0x1e2ef,
+    }, // [2]u21{ nil }                   ..
+    [2]u21{
+        0x1e8d0,
+        0x1e8d6,
+    }, // Mende Kikakui Combining ..Mende Kikakui Combining
+    [2]u21{
+        0x1e944,
+        0x1e94a,
+    }, // Adlam Alif Lengthener   ..Adlam Nukta
+    [2]u21{
+        0xe0100,
+        0xe01ef,
+    }, // Variation Selector-17   ..Variation Selector-256
+};

--- a/src/main.zig
+++ b/src/main.zig
@@ -33,11 +33,7 @@ pub fn main() !void {
         }
     }
 
-    var buf_reader = std.io.bufferedReader(std.io.getStdIn().reader());
-    const in = buf_reader.reader();
-    const stdout = std.io.getStdOut().writer();
-
-    try repl.run(gpa, in, stdout);
+    try repl.run(gpa, std.io.getStdIn(), std.io.getStdOut());
 }
 
 const usage =


### PR DESCRIPTION
Hey, I sketched out what using linenoize might look like with the repl. Linenoize seems to want to work with `std.fs.File`s instead of readers and writers, otherwise I tried my best not to touch the current repl behavior.

This probably should not be merged at the moment since linenoize did not compile with zig master, I submitted a PR but it is yet to be finalized!