### PR TITLE
Garbage collector reimplementation

### DIFF
--- a/src/Gc.zig
+++ b/src/Gc.zig
@@ -24,7 +24,6 @@ const Object = struct {
 
 /// tracks live objects in a block of memory
 const Page = struct {
-    // TODO instead use powers of 4 or 8?
     const SET_SIZE = PAGE_LEN << 1;
     /// the index into StateSet that represents the first object
     const SET_BASE = PAGE_LEN;
@@ -94,6 +93,11 @@ const Page = struct {
         self.chalkboard.unset(bit.index - 1);
     }
 
+    /// whether an object lives
+    fn lives(self: *Page, index: usize) bool {
+        return self.get(Bit.of(index + SET_BASE));
+    }
+
     /// estimates how full this page is to determine whether it is 'saturated'
     /// (should be collected)
     fn isSaturated(self: *const Page) bool {
@@ -128,9 +132,9 @@ const Page = struct {
         }
 
         for (self.data) |*obj, index| {
-            if (obj.generation != gen) {
-                obj.value.deinit(ally);
+            if (self.lives(index) and obj.generation != gen) {
                 self.setFree(index);
+                obj.value.deinit(ally);
             }
         }
     }

--- a/src/Gc.zig
+++ b/src/Gc.zig
@@ -31,6 +31,7 @@ const Page = struct {
 
     /// the raw object memory
     data: [PAGE_LEN]Object = undefined,
+    max_used: usize = 0,
     /// used to track empty objects
     chalkboard: StateSet = StateSet.initEmpty(),
 
@@ -138,8 +139,12 @@ const Page = struct {
     }
 
     /// finds the index of the first free object
-    fn firstFreeObject(self: *const Page) ?usize {
-        if (self.isFull()) {
+    fn firstFreeObject(self: *Page) ?usize {
+        if (self.max_used < self.data.len) {
+            const index = self.max_used;
+            self.max_used += 1;
+            return index;
+        } else if (self.isFull()) {
             return null;
         }
 

--- a/src/List.zig
+++ b/src/List.zig
@@ -38,7 +38,7 @@ pub fn get(list: *const List, ctx: Vm.Context, index: *const Value, res: *?*Valu
             if (r.start < 0 or r.end > list.inner.items.len)
                 return ctx.throw("index out of bounds");
 
-            res.* = try ctx.vm.gc.alloc(.list);
+            res.* = try ctx.vm.gc.alloc();
             res.*.?.* = .{ .list = .{} };
             const res_list = &res.*.?.*.list;
             try res_list.inner.ensureUnusedCapacity(ctx.vm.gc.gpa, r.count());
@@ -50,7 +50,7 @@ pub fn get(list: *const List, ctx: Vm.Context, index: *const Value, res: *?*Valu
         },
         .str => |s| {
             if (res.* == null) {
-                res.* = try ctx.vm.gc.alloc(.int);
+                res.* = try ctx.vm.gc.alloc();
             }
 
             if (mem.eql(u8, s.data, "len")) {

--- a/src/String.zig
+++ b/src/String.zig
@@ -84,7 +84,7 @@ pub fn get(str: *const String, ctx: Vm.Context, index: *const Value, res: *?*Val
         .range => return ctx.frame.fatal(ctx.vm, "TODO str get with ranges"),
         .str => |*s| {
             if (res.* == null) {
-                res.* = try ctx.vm.gc.alloc(.int);
+                res.* = try ctx.vm.gc.alloc();
             }
 
             if (mem.eql(u8, s.data, "len")) {
@@ -190,14 +190,14 @@ pub const methods = struct {
             return ctx.throw("unused arguments");
         }
 
-        const ret = try ctx.vm.gc.alloc(.str);
+        const ret = try ctx.vm.gc.alloc();
         ret.* = Value{ .str = b.finish() };
         return ret;
     }
 
     pub fn join(str: Value.This([]const u8), ctx: Vm.Context, strs: Value.Variadic([]const u8)) !*Value {
         if (strs.t.len == 0) {
-            const ret = try ctx.vm.gc.alloc(.str);
+            const ret = try ctx.vm.gc.alloc();
             ret.* = Value.string("");
             return ret;
         }
@@ -215,7 +215,7 @@ pub const methods = struct {
             b.inner.appendSliceAssumeCapacity(arg);
         }
 
-        const ret = try ctx.vm.gc.alloc(.str);
+        const ret = try ctx.vm.gc.alloc();
         ret.* = Value{ .str = b.finish() };
         return ret;
     }
@@ -240,7 +240,7 @@ pub fn as(str: *String, ctx: Vm.Context, type_id: Type) Value.NativeError!*Value
             return ctx.throw("cannot cast string to bool");
     }
 
-    const new_val = try ctx.vm.gc.alloc(type_id);
+    const new_val = try ctx.vm.gc.alloc();
     new_val.* = switch (type_id) {
         .int => .{
             .int = std.fmt.parseInt(i64, str.data, 0) catch |err|
@@ -262,7 +262,7 @@ pub fn as(str: *String, ctx: Vm.Context, type_id: Type) Value.NativeError!*Value
 }
 
 pub fn from(val: *Value, vm: *Vm) Vm.Error!*Value {
-    const str = try vm.gc.alloc(.str);
+    const str = try vm.gc.alloc();
 
     if (val == Value.Null) {
         str.* = Value.string("null");

--- a/src/Vm.zig
+++ b/src/Vm.zig
@@ -40,11 +40,6 @@ pub const Options = struct {
 
     /// maximum size of imported files
     max_import_size: u32 = 5 * 1024 * 1024,
-
-    /// maximum amount of pages gc may allocate.
-    /// 1 page == 1 MiB.
-    /// default 2 GiB.
-    page_limit: u32 = 2048,
 };
 
 /// NOTE: should be ?*Value, but that makes stage1 shit its pants.
@@ -226,7 +221,7 @@ pub const Error = error{FatalError} || Allocator.Error;
 
 pub fn init(allocator: Allocator, options: Options) Vm {
     return .{
-        .gc = Gc.init(allocator, options.page_limit),
+        .gc = Gc.init(allocator),
         .errors = Errors.init(allocator),
         .options = options,
     };

--- a/src/main.zig
+++ b/src/main.zig
@@ -63,12 +63,12 @@ fn run(gpa: std.mem.Allocator, args: [][]const u8) !void {
         var _args: [][]const u8 = undefined;
 
         fn argsToBog(ctx: bog.Vm.Context) bog.Vm.Error!*bog.Value {
-            const ret = try ctx.vm.gc.alloc(.list);
+            const ret = try ctx.vm.gc.alloc();
             ret.* = .{ .list = .{} };
             try ret.list.inner.ensureTotalCapacity(ctx.vm.gc.gpa, _args.len);
 
             for (_args) |arg| {
-                const str = try ctx.vm.gc.alloc(.str);
+                const str = try ctx.vm.gc.alloc();
                 str.* = bog.Value.string(arg);
                 ret.list.inner.appendAssumeCapacity(str);
             }

--- a/src/std.zig
+++ b/src/std.zig
@@ -5,8 +5,3 @@ pub const os = @import("std/os.zig");
 pub const map = @import("std/map.zig");
 pub const debug = @import("std/debug.zig");
 pub const json = @import("std/json.zig");
-pub const gc = struct {
-    pub fn collect(ctx: @import("bog.zig").Vm.Context) i64 {
-        return @intCast(i64, ctx.vm.gc.collect());
-    }
-};

--- a/src/std/fs.zig
+++ b/src/std/fs.zig
@@ -5,7 +5,7 @@ const Vm = bog.Vm;
 
 pub fn open(ctx: Vm.Context, path: []const u8) !*Value {
     // TODO take options as parameters
-    const res = try ctx.vm.gc.alloc(.native_val);
+    const res = try ctx.vm.gc.alloc();
     res.* = .{ .native_val = .{
         .vtable = Value.NativeVal.VTable.get(File),
         .type_id = Value.NativeVal.typeId(File),
@@ -34,7 +34,7 @@ const File = struct {
         switch (index.*) {
             .str => |*s| {
                 if (res.* == null) {
-                    res.* = try ctx.vm.gc.alloc(.int);
+                    res.* = try ctx.vm.gc.alloc();
                 }
 
                 inline for (@typeInfo(methods).Struct.decls) |method| {

--- a/src/std/json.zig
+++ b/src/std/json.zig
@@ -14,7 +14,7 @@ const Error = error{ UnexpectedToken, UnexpectedEndOfJson } || std.mem.Allocator
 fn parseInternal(vm: *Vm, token: std.json.Token, tokens: *std.json.TokenStream) Error!*Value {
     switch (token) {
         .ObjectBegin => {
-            const res = try vm.gc.alloc(.map);
+            const res = try vm.gc.alloc();
             res.* = .{ .map = .{} };
 
             while (true) {
@@ -31,7 +31,7 @@ fn parseInternal(vm: *Vm, token: std.json.Token, tokens: *std.json.TokenStream) 
             return res;
         },
         .ArrayBegin => {
-            const res = try vm.gc.alloc(.list);
+            const res = try vm.gc.alloc();
             res.* = .{ .list = .{} };
 
             while (true) {
@@ -47,7 +47,7 @@ fn parseInternal(vm: *Vm, token: std.json.Token, tokens: *std.json.TokenStream) 
         .ObjectEnd, .ArrayEnd => return error.UnexpectedToken,
         .String => |info| {
             const source_slice = info.slice(tokens.slice, tokens.i - 1);
-            const val = try vm.gc.alloc(.str);
+            const val = try vm.gc.alloc();
             switch (info.escapes) {
                 .None => val.* = Value.string(try vm.gc.gpa.dupe(u8, source_slice)),
                 .Some => {
@@ -60,7 +60,7 @@ fn parseInternal(vm: *Vm, token: std.json.Token, tokens: *std.json.TokenStream) 
             return val;
         },
         .Number => |info| {
-            const val = try vm.gc.alloc(.int);
+            const val = try vm.gc.alloc();
             if (info.is_integer) {
                 val.* = .{ .int = try std.fmt.parseInt(i64, info.slice(tokens.slice, tokens.i - 1), 10) };
             } else {

--- a/src/std/map.zig
+++ b/src/std/map.zig
@@ -6,7 +6,7 @@ const Vm = bog.Vm;
 /// Creates a list of the maps keys
 pub fn keys(ctx: Vm.Context, map: *const Value.Map) !*Value {
     const gc = &ctx.vm.gc;
-    var ret = try gc.alloc(.list);
+    var ret = try gc.alloc();
     ret.* = .{ .list = .{} };
     try ret.list.inner.resize(gc.gpa, map.count());
     const items = ret.list.inner.items;
@@ -23,7 +23,7 @@ pub fn keys(ctx: Vm.Context, map: *const Value.Map) !*Value {
 /// Creates a list of the maps values
 pub fn values(ctx: Vm.Context, map: *const Value.Map) !*Value {
     const gc = &ctx.vm.gc;
-    var ret = try gc.alloc(.list);
+    var ret = try gc.alloc();
     ret.* = .{ .list = .{} };
     try ret.list.inner.resize(gc.gpa, map.count());
     const items = ret.list.inner.items;
@@ -40,7 +40,7 @@ pub fn values(ctx: Vm.Context, map: *const Value.Map) !*Value {
 /// Creates a list of kv pairs
 pub fn entries(ctx: Vm.Context, map: *const Value.Map) !*Value {
     const gc = &ctx.vm.gc;
-    var ret = try ctx.vm.gc.alloc(.list);
+    var ret = try ctx.vm.gc.alloc();
     ret.* = .{ .list = .{} };
     try ret.list.inner.resize(gc.gpa, map.count());
     const items = ret.list.inner.items;
@@ -48,7 +48,7 @@ pub fn entries(ctx: Vm.Context, map: *const Value.Map) !*Value {
     var i: usize = 0;
     var iter = map.iterator();
     while (iter.next()) |e| : (i += 1) {
-        var entry = try gc.alloc(.map);
+        var entry = try gc.alloc();
         entry.* = .{ .map = .{} };
         try entry.map.ensureTotalCapacity(gc.gpa, 2);
 

--- a/src/std/math.zig
+++ b/src/std/math.zig
@@ -38,12 +38,12 @@ pub fn ln(ctx: Vm.Context, val: *Value) !*Value {
     switch (val.*) {
         .int => |i| {
             if (i <= 0) return ctx.throw("ln is undefined for numbers less than zero");
-            const res = try ctx.vm.gc.alloc(.int);
+            const res = try ctx.vm.gc.alloc();
             res.* = Value{ .int = std.math.lossyCast(i64, std.math.floor(std.math.ln(@intToFloat(f64, i)))) };
             return res;
         },
         .num => |n| {
-            const res = try ctx.vm.gc.alloc(.num);
+            const res = try ctx.vm.gc.alloc();
             res.* = Value{ .num = std.math.ln(n) };
             return res;
         },
@@ -54,12 +54,12 @@ pub fn ln(ctx: Vm.Context, val: *Value) !*Value {
 pub fn sqrt(ctx: Vm.Context, val: *Value) !*Value {
     return switch (val.*) {
         .int => |i| {
-            const res = try ctx.vm.gc.alloc(.int);
+            const res = try ctx.vm.gc.alloc();
             res.* = Value{ .int = std.math.sqrt(@intCast(u64, i)) };
             return res;
         },
         .num => |n| {
-            const res = try ctx.vm.gc.alloc(.num);
+            const res = try ctx.vm.gc.alloc();
             res.* = Value{ .num = std.math.sqrt(n) };
             return res;
         },

--- a/tests/behavior.zig
+++ b/tests/behavior.zig
@@ -82,7 +82,7 @@ test "capture" {
     try expectOutput(
         \\let foo = fn()
         \\    let a = 1
-        \\    return fn() 
+        \\    return fn()
         \\        return a + 1
         \\
         \\return foo()()
@@ -117,25 +117,6 @@ test "continue" {
         \\for let i in 0:1
         \\    continue
     , "null");
-}
-
-test "std.gc" {
-    if (@import("builtin").os.tag == .windows) {
-        // TODO this gives a different result on windows
-        return error.SkipZigTest;
-    }
-    try expectOutput(
-        \\let {collect} = import "std.gc"
-        \\let json = import "std.json"
-        \\
-        \\let makeGarbage = fn()
-        \\    json.stringify({"a" = [2, "foo", null]})
-        \\
-        \\for 0:5 makeGarbage()
-        \\return collect()
-    ,
-        \\53
-    );
 }
 
 test "std.json" {


### PR DESCRIPTION
A pretty simple mark-sweep garbage collector. In most cases this should be similarly performant to a bump allocator.

The most interesting thing about it is the used/free object tracking, which uses a bit set in with a binary-heap indexing strategy to keep track of objects that are either in use or not collected yet, the idea being that looking for a free object in a relatively full list should remain fast. I'm not sure this is actually more useful than keeping a simple list of freed indices, but I thought the idea was worth taking a stab at.